### PR TITLE
feat(VR-6): JustJoinConnector

### DIFF
--- a/.claude/agents/scraper-agent.md
+++ b/.claude/agents/scraper-agent.md
@@ -4,11 +4,21 @@
 This agent owns `radar.connector` and the scraping part of `radar.service`.
 
 ## Responsibilities
-- `JustJoinConnector`: HTTP GET with browser-like headers, Jsoup parsing of `__NEXT_DATA__` JSON
-- Pagination over job offer pages until empty result
-- Per-offer detail fetch (`/job-offer/{slug}`) to obtain plain-text description
+- `JustJoinConnector`: HTTP GET against the justjoin.it JSON API with browser-like headers, Jackson parsing of the JSON response
+- Pagination driven by `meta.totalPages`
 - Rate limiting: `Thread.sleep(500 + random(500))` between requests
 - `ScraperService`: deduplication against `seen-ids.json`, returns only new `RawJobOffer` list
+
+## Data source (as of 2026)
+justjoin.it is now a React Server Components app — the old `__NEXT_DATA__` script tag no longer
+exists. Offers come from the public JSON API:
+
+- Endpoint: `https://api.justjoin.it/v2/user-panel/offers?categories[]=6&page=N&perPage=100`
+- **Required** header: `Version: 2` (otherwise HTTP 404)
+- Java is `categoryId=6`
+- The list endpoint does **not** include the full job description (it lives only in the page's RSC
+  payload, with no stable JSON endpoint), so `RawJobOffer.description` is left null. Per-offer
+  description fetching is a separate follow-up task.
 
 ## Does NOT know about
 - Claude API or enrichment
@@ -16,6 +26,6 @@ This agent owns `radar.connector` and the scraping part of `radar.service`.
 - Writing to `jobs.json`
 
 ## Key constraints
-- No raw HTML in `RawJobOffer.description` — use Jsoup `.text()`
-- No Selenium — pure HTTP + Jsoup only
+- No raw HTML in `RawJobOffer.description` — use Jsoup `.text()` if/when a description is fetched
+- No Selenium — pure HTTP only (JDK `HttpClient`) + Jackson/Jsoup
 - No database, no external queues

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -3,10 +3,10 @@
 ## High-Level Flow
 
 ```
-JustJoin HTML
+JustJoin JSON API (api.justjoin.it/v2/user-panel/offers, categoryId=6, Version: 2)
     │
     ▼
-JustJoinConnector (Jsoup → __NEXT_DATA__ → List<RawJobOffer>)
+JustJoinConnector (HttpClient → Jackson → List<RawJobOffer>, paginated by meta.totalPages)
     │
     ▼
 ScraperService
@@ -27,7 +27,7 @@ ScraperService
 
 | Component | Responsibility |
 |---|---|
-| `JustJoinConnector` | HTTP scraping, `__NEXT_DATA__` parsing, pagination |
+| `JustJoinConnector` | JustJoin JSON API client, Jackson parsing, pagination |
 | `ScraperService` | orchestrates scan, deduplication, coordinates enrichment |
 | `EnricherService` | sends RawJobOffer + UserProfile to Claude Haiku, returns JobReport |
 | `ReporterService` | aggregates Analytics, saves snapshots |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@
 - Java 25
 - Spring Boot 4.0.3
 - Gradle
-- Jsoup (parsing `__NEXT_DATA__` from JustJoin HTML)
+- JustJoin JSON API (`api.justjoin.it/v2/user-panel/offers`, `Version: 2` header, Java = `categoryId=6`)
+- Jsoup (HTML→text for job descriptions when fetched)
 - Jackson (JSON mapping)
 - Anthropic Java SDK (Claude Haiku — model `claude-haiku-4-5-20251001`)
 

--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -1,0 +1,177 @@
+package radar.connector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import radar.model.RawJobOffer;
+
+/**
+ * Scrapes Java job offers from justjoin.it.
+ *
+ * <p>Historically justjoin.it embedded offer data in a {@code __NEXT_DATA__} script tag. As of 2026
+ * the site is a React Server Components app and no longer exposes that. Instead we call its public
+ * JSON API ({@code api.justjoin.it/v2/user-panel/offers}), which requires a {@code Version: 2}
+ * header and a {@code categories[]} filter. Java is {@code categoryId=6}.
+ *
+ * <p>The list endpoint does not carry the full job description (that lives only in the page's RSC
+ * payload and has no stable JSON endpoint), so {@link RawJobOffer#description()} is left null here.
+ * Fetching descriptions is deliberately out of scope for this connector — see {@link #DESCRIPTION_NOTE}.
+ */
+@Component
+public class JustJoinConnector {
+
+  static final String DESCRIPTION_NOTE =
+      "Description is not available from the list API; a follow-up task will add per-offer fetching.";
+
+  private static final Logger log = LoggerFactory.getLogger(JustJoinConnector.class);
+
+  private static final String API_BASE = "https://api.justjoin.it/v2/user-panel/offers";
+  private static final int JAVA_CATEGORY_ID = 6;
+  private static final int PER_PAGE = 100;
+  private static final int MAX_PAGES_SAFETY = 500;
+  private static final String USER_AGENT =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+          + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+  private static final String SOURCE = "justjoin";
+
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+
+  public JustJoinConnector(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.httpClient =
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
+  }
+
+  /**
+   * Fetches every Java offer across all pages. Rate-limits between requests to stay polite.
+   */
+  public List<RawJobOffer> fetchAll() {
+    List<RawJobOffer> all = new ArrayList<>();
+    int page = 1;
+    int totalPages = 1;
+    while (page <= totalPages && page <= MAX_PAGES_SAFETY) {
+      JsonNode root = fetchPage(page);
+      totalPages = root.path("meta").path("totalPages").asInt(1);
+      List<RawJobOffer> offers = parseOffers(root);
+      all.addAll(offers);
+      log.info("JustJoin page {}/{}: {} offers ({} total)", page, totalPages, offers.size(),
+          all.size());
+      page++;
+      if (page <= totalPages) {
+        sleepPolitely();
+      }
+    }
+    return all;
+  }
+
+  private JsonNode fetchPage(int page) {
+    String url = API_BASE + "?categories%5B%5D=" + JAVA_CATEGORY_ID + "&page=" + page + "&perPage="
+        + PER_PAGE;
+    HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+        .header("User-Agent", USER_AGENT)
+        .header("Accept", "application/json")
+        .header("Referer", "https://justjoin.it/")
+        .header("Version", "2")
+        .timeout(Duration.ofSeconds(30))
+        .GET()
+        .build();
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new IllegalStateException(
+            "JustJoin API returned HTTP " + response.statusCode() + " for page " + page);
+      }
+      return objectMapper.readTree(response.body());
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to fetch JustJoin page " + page, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted fetching JustJoin page " + page, e);
+    }
+  }
+
+  /**
+   * Parses one API page's JSON into raw offers. Package-private so it can be unit-tested with a
+   * fixture, without touching the network.
+   */
+  List<RawJobOffer> parseOffers(JsonNode root) {
+    List<RawJobOffer> offers = new ArrayList<>();
+    for (JsonNode node : root.path("data")) {
+      offers.add(toRawJobOffer(node));
+    }
+    return offers;
+  }
+
+  private RawJobOffer toRawJobOffer(JsonNode n) {
+    String slug = textOrNull(n, "slug");
+    JsonNode salary = n.path("employmentTypes").path(0);
+    return new RawJobOffer(
+        textOrNull(n, "guid"),
+        textOrNull(n, "title"),
+        textOrNull(n, "companyName"),
+        null, // companySize — not present in the list API
+        textOrNull(n, "city"),
+        "remote".equalsIgnoreCase(textOrNull(n, "workplaceType")),
+        textOrNull(n, "publishedAt"),
+        textOrNull(n, "experienceLevel"),
+        null, // description — see DESCRIPTION_NOTE
+        readSkills(n.path("requiredSkills")),
+        intOrNull(salary, "from"),
+        intOrNull(salary, "to"),
+        upperOrNull(salary, "currency"),
+        textOrNull(salary, "type"),
+        slug == null ? null : "https://justjoin.it/job-offer/" + slug,
+        SOURCE);
+  }
+
+  private static List<String> readSkills(JsonNode skillsNode) {
+    List<String> skills = new ArrayList<>();
+    if (skillsNode.isArray()) {
+      for (JsonNode s : skillsNode) {
+        // requiredSkills may be an array of strings or of objects with a "name" field
+        if (s.isTextual()) {
+          skills.add(s.asText());
+        } else if (s.hasNonNull("name")) {
+          skills.add(s.get("name").asText());
+        }
+      }
+    }
+    return skills;
+  }
+
+  private static String textOrNull(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return v == null || v.isNull() ? null : v.asText();
+  }
+
+  private static String upperOrNull(JsonNode node, String field) {
+    String v = textOrNull(node, field);
+    return v == null ? null : v.toUpperCase();
+  }
+
+  private static Integer intOrNull(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return v == null || v.isNull() || !v.isNumber() ? null : v.asInt();
+  }
+
+  private void sleepPolitely() {
+    try {
+      Thread.sleep(500 + ThreadLocalRandom.current().nextInt(500));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/test/java/radar/connector/JustJoinConnectorTest.java
+++ b/src/test/java/radar/connector/JustJoinConnectorTest.java
@@ -1,0 +1,123 @@
+package radar.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import radar.model.RawJobOffer;
+
+/**
+ * Unit tests for the JSON-API parsing (no network). Fixtures mirror the shape of
+ * {@code api.justjoin.it/v2/user-panel/offers}.
+ */
+class JustJoinConnectorTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final JustJoinConnector connector = new JustJoinConnector(mapper);
+
+  private JsonNode json(String s) throws Exception {
+    return mapper.readTree(s);
+  }
+
+  @Test
+  void mapsAFullyPopulatedOffer() throws Exception {
+    JsonNode page = json("""
+        {
+          "meta": {"page": 1, "totalPages": 1},
+          "data": [
+            {
+              "guid": "abc-123",
+              "slug": "acme-senior-java-dev-krakow-java",
+              "title": "Senior Java Developer",
+              "companyName": "Acme",
+              "city": "Kraków",
+              "workplaceType": "remote",
+              "experienceLevel": "senior",
+              "publishedAt": "2026-06-10T16:39:31.585Z",
+              "requiredSkills": ["Java", "Spring Boot", "AWS"],
+              "employmentTypes": [
+                {"from": 18000, "to": 26000, "currency": "pln", "type": "b2b"}
+              ]
+            }
+          ]
+        }
+        """);
+
+    List<RawJobOffer> offers = connector.parseOffers(page);
+
+    assertThat(offers).hasSize(1);
+    RawJobOffer o = offers.get(0);
+    assertThat(o.id()).isEqualTo("abc-123");
+    assertThat(o.title()).isEqualTo("Senior Java Developer");
+    assertThat(o.companyName()).isEqualTo("Acme");
+    assertThat(o.location()).isEqualTo("Kraków");
+    assertThat(o.remote()).isTrue();
+    assertThat(o.experienceLevel()).isEqualTo("senior");
+    assertThat(o.publishedAt()).isEqualTo("2026-06-10T16:39:31.585Z");
+    assertThat(o.skills()).containsExactly("Java", "Spring Boot", "AWS");
+    assertThat(o.salaryMin()).isEqualTo(18000);
+    assertThat(o.salaryMax()).isEqualTo(26000);
+    assertThat(o.currency()).isEqualTo("PLN");
+    assertThat(o.contractType()).isEqualTo("b2b");
+    assertThat(o.applyUrl()).isEqualTo("https://justjoin.it/job-offer/acme-senior-java-dev-krakow-java");
+    assertThat(o.sourceConnector()).isEqualTo("justjoin");
+    assertThat(o.description()).isNull(); // not available from the list API
+    assertThat(o.companySize()).isNull();
+  }
+
+  @Test
+  void handlesMissingSkillsSalaryAndNonRemote() throws Exception {
+    JsonNode page = json("""
+        {
+          "meta": {"page": 1, "totalPages": 1},
+          "data": [
+            {
+              "guid": "def-456",
+              "slug": "x-java-dev-warszawa-java",
+              "title": "Java Dev",
+              "companyName": "Globex",
+              "city": "Warszawa",
+              "workplaceType": "hybrid",
+              "experienceLevel": "mid",
+              "requiredSkills": null,
+              "employmentTypes": []
+            }
+          ]
+        }
+        """);
+
+    RawJobOffer o = connector.parseOffers(page).get(0);
+    assertThat(o.remote()).isFalse();
+    assertThat(o.skills()).isEmpty();
+    assertThat(o.salaryMin()).isNull();
+    assertThat(o.salaryMax()).isNull();
+    assertThat(o.currency()).isNull();
+    assertThat(o.contractType()).isNull();
+  }
+
+  @Test
+  void readsSkillsGivenAsObjects() throws Exception {
+    JsonNode page = json("""
+        {
+          "data": [
+            {
+              "guid": "g", "slug": "s", "title": "t", "companyName": "c",
+              "requiredSkills": [{"name": "Java", "level": 4}, {"name": "Kafka", "level": 2}],
+              "employmentTypes": []
+            }
+          ]
+        }
+        """);
+
+    RawJobOffer o = connector.parseOffers(page).get(0);
+    assertThat(o.skills()).containsExactly("Java", "Kafka");
+  }
+
+  @Test
+  void emptyDataYieldsEmptyList() throws Exception {
+    assertThat(connector.parseOffers(json("{\"data\": []}"))).isEmpty();
+    assertThat(connector.parseOffers(json("{}"))).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.connector.JustJoinConnector` fetching Java offers from justjoin.it
- **Important:** the site dropped `__NEXT_DATA__` (now React Server Components), so this uses the public JSON API `api.justjoin.it/v2/user-panel/offers` — requires a `Version: 2` header (else HTTP 404), Java is `categoryId=6`, pagination driven by `meta.totalPages`, rate-limited between requests
- Maps list fields → `RawJobOffer` via Jackson; parsing split from HTTP so it's unit-tested on JSON fixtures (4 tests)
- `description` is intentionally left null (only present in the page RSC payload, no stable detail endpoint) — MVP; a follow-up will add per-offer descriptions
- Updated `scraper-agent.md`, `CLAUDE.md`, `architecture.md` to reflect the API approach

## Test plan
- `./gradlew build` green; connector parser tests cover full offer, missing skills/salary, object-shaped skills, empty data

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)