### PR TITLE
chore(docs): update connector rules for JustJoin JSON API

### DIFF
--- a/.claude/rules/connector-development.md
+++ b/.claude/rules/connector-development.md
@@ -7,13 +7,17 @@ paths:
 
 ## JustJoinConnector Rules
 
-- HTTP GET `https://justjoin.it/job-offers/all-locations/java`
-- Jsoup extracts `<script id="__NEXT_DATA__">` → Jackson maps to `List<RawJobOffer>`
-- Pagination: `page=2, page=3...`
-- Per offer: GET `/job-offer/{slug}` → full details
+- Data source is the JSON API, NOT `__NEXT_DATA__` (that script tag no longer exists — the site
+  is a React Server Components app as of 2026).
+- HTTP GET `https://api.justjoin.it/v2/user-panel/offers?categories[]=6&page=N&perPage=100`
+- **Required** header `Version: 2` (otherwise HTTP 404). Java = `categoryId=6`.
+- Jackson maps the JSON `data[]` → `List<RawJobOffer>`; paginate via `meta.totalPages`
 - Rate limiting: 500–1000ms between requests
-- Required headers: `User-Agent`, `Referer`
+- Required headers: `User-Agent`, `Referer`, `Accept: application/json`, `Version: 2`
+- Use JDK `HttpClient` for the API (Jsoup only for HTML→text if a description is ever fetched)
 - No Selenium
+- `description` is not in the list API (only in the page RSC payload) → left null; per-offer
+  description fetching is a separate follow-up task
 
 ## Adding New Connectors (Phase 2)
 


### PR DESCRIPTION
## Summary
- Update `.claude/rules/connector-development.md` to describe the JSON API (`Version: 2` header, `categoryId=6`, `meta.totalPages` pagination) instead of the removed `__NEXT_DATA__` approach
- Matches the VR-6 connector; notes descriptions are a follow-up (#22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)