### PR TITLE
feat(VR-5): File Repository

### DIFF
--- a/src/main/java/radar/repository/JsonRepository.java
+++ b/src/main/java/radar/repository/JsonRepository.java
@@ -1,0 +1,212 @@
+package radar.repository;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.UserProfile;
+
+/**
+ * Reads and writes the application's JSON files under the data directory. There is no database —
+ * everything is date-partitioned JSON on disk (see {@code .claude/rules/data-storage.md}).
+ *
+ * <p>Layout:
+ * <pre>
+ *   {dataDir}/profile.json
+ *   {dataDir}/seen-ids.json
+ *   {dataDir}/{YYYY-MM-DD}/jobs.json
+ *   {dataDir}/{YYYY-MM-DD}/analytics.json
+ * </pre>
+ *
+ * <p>All access is guarded by a {@link ReentrantReadWriteLock} so concurrent scans don't corrupt a
+ * file. Writes are pretty-printed so the files stay human-inspectable.
+ */
+@Component
+public class JsonRepository {
+
+  private static final String PROFILE_FILE = "profile.json";
+  private static final String SEEN_IDS_FILE = "seen-ids.json";
+  private static final String JOBS_FILE = "jobs.json";
+  private static final String ANALYTICS_FILE = "analytics.json";
+  private static final Pattern DATE_DIR = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+  private final ObjectMapper objectMapper;
+  private final Path dataDir;
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+  public JsonRepository(ObjectMapper objectMapper, @Value("${radar.data.dir:data}") String dataDir) {
+    this.objectMapper = objectMapper;
+    this.dataDir = Path.of(dataDir);
+    ensureDir(this.dataDir);
+  }
+
+  // ---- profile ----
+
+  public UserProfile readProfile() {
+    return read(dataDir.resolve(PROFILE_FILE), UserProfile.class);
+  }
+
+  public void writeProfile(UserProfile profile) {
+    write(dataDir.resolve(PROFILE_FILE), profile);
+  }
+
+  // ---- seen ids ----
+
+  /** Returns the deduplication list, or an empty list if it doesn't exist yet. */
+  public List<String> readSeenIds() {
+    lock.readLock().lock();
+    try {
+      Path file = dataDir.resolve(SEEN_IDS_FILE);
+      if (!Files.exists(file)) {
+        return new ArrayList<>();
+      }
+      return objectMapper.readValue(Files.readAllBytes(file), new TypeReference<List<String>>() {});
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + SEEN_IDS_FILE, e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /** Merges {@code newIds} into the existing list, dropping duplicates, and persists the result. */
+  public void appendSeenIds(List<String> newIds) {
+    lock.writeLock().lock();
+    try {
+      LinkedHashSet<String> merged = new LinkedHashSet<>(readSeenIdsUnlocked());
+      merged.addAll(newIds);
+      writeUnlocked(dataDir.resolve(SEEN_IDS_FILE), new ArrayList<>(merged));
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  // ---- jobs ----
+
+  public void saveJobs(String date, List<JobReport> jobs) {
+    write(dateDir(date).resolve(JOBS_FILE), jobs);
+  }
+
+  /** Returns the saved reports for a date, or an empty list if none were saved. */
+  public List<JobReport> loadJobs(String date) {
+    lock.readLock().lock();
+    try {
+      Path file = dateDir(date).resolve(JOBS_FILE);
+      if (!Files.exists(file)) {
+        return new ArrayList<>();
+      }
+      return objectMapper.readValue(Files.readAllBytes(file),
+          new TypeReference<List<JobReport>>() {});
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read jobs for " + date, e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  // ---- analytics ----
+
+  public void saveAnalytics(String date, Analytics analytics) {
+    write(dateDir(date).resolve(ANALYTICS_FILE), analytics);
+  }
+
+  public Analytics loadAnalytics(String date) {
+    return read(dateDir(date).resolve(ANALYTICS_FILE), Analytics.class);
+  }
+
+  // ---- dates ----
+
+  /** Lists the {@code YYYY-MM-DD} snapshot directories under the data dir, ascending. */
+  public List<String> listDates() {
+    lock.readLock().lock();
+    try {
+      if (!Files.isDirectory(dataDir)) {
+        return new ArrayList<>();
+      }
+      try (Stream<Path> entries = Files.list(dataDir)) {
+        return entries
+            .filter(Files::isDirectory)
+            .map(p -> p.getFileName().toString())
+            .filter(name -> DATE_DIR.matcher(name).matches())
+            .sorted()
+            .toList();
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to list dates in " + dataDir, e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  // ---- internals ----
+
+  private List<String> readSeenIdsUnlocked() throws RuntimeException {
+    Path file = dataDir.resolve(SEEN_IDS_FILE);
+    if (!Files.exists(file)) {
+      return new ArrayList<>();
+    }
+    try {
+      return objectMapper.readValue(Files.readAllBytes(file), new TypeReference<List<String>>() {});
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + SEEN_IDS_FILE, e);
+    }
+  }
+
+  private Path dateDir(String date) {
+    return dataDir.resolve(date);
+  }
+
+  private <T> T read(Path file, Class<T> type) {
+    lock.readLock().lock();
+    try {
+      if (!Files.exists(file)) {
+        throw new IllegalStateException("File not found: " + file);
+      }
+      return objectMapper.readValue(Files.readAllBytes(file), type);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + file, e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  private void write(Path file, Object value) {
+    lock.writeLock().lock();
+    try {
+      writeUnlocked(file, value);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  private void writeUnlocked(Path file, Object value) {
+    try {
+      ensureDir(file.getParent());
+      byte[] bytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(value);
+      Files.write(file, bytes);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to write " + file, e);
+    }
+  }
+
+  private static void ensureDir(Path dir) {
+    try {
+      if (dir != null) {
+        Files.createDirectories(dir);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create directory " + dir, e);
+    }
+  }
+}

--- a/src/test/java/radar/repository/JsonRepositoryTest.java
+++ b/src/test/java/radar/repository/JsonRepositoryTest.java
@@ -1,0 +1,112 @@
+package radar.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.SalaryRange;
+import radar.model.UserProfile;
+
+class JsonRepositoryTest {
+
+  @TempDir
+  Path tmp;
+
+  private JsonRepository repo;
+
+  @BeforeEach
+  void setUp() {
+    // point the repo at a fresh sub-dir that does NOT exist yet, to prove auto-creation
+    repo = new JsonRepository(new ObjectMapper(), tmp.resolve("data").toString());
+  }
+
+  @Test
+  void createsDataDirIfMissing() {
+    assertThat(Files.isDirectory(tmp.resolve("data"))).isTrue();
+  }
+
+  @Test
+  void profileRoundTrips() {
+    UserProfile profile = new UserProfile(
+        List.of("Java", "Spring"), 3, "B2B", true, 15000, "PLN", "B2B",
+        List.of("Warsaw", "Remote"), 6);
+    repo.writeProfile(profile);
+    assertThat(repo.readProfile()).isEqualTo(profile);
+  }
+
+  @Test
+  void readProfileThrowsWhenMissing() {
+    assertThatThrownBy(() -> repo.readProfile()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void seenIdsStartEmptyAndDeduplicateAcrossAppends() {
+    assertThat(repo.readSeenIds()).isEmpty();
+
+    repo.appendSeenIds(List.of("a", "b", "c"));
+    repo.appendSeenIds(List.of("b", "c", "d")); // b, c already present
+    repo.appendSeenIds(List.of("a", "e"));      // a already present
+
+    assertThat(repo.readSeenIds()).containsExactly("a", "b", "c", "d", "e");
+  }
+
+  @Test
+  void jobsRoundTrip() {
+    RawJobOffer offer = new RawJobOffer(
+        "jj-1", "Java Dev", "Acme", "50", "Kraków", true, "2026-07-04", "mid",
+        null, List.of("Java"), 12000, 18000, "PLN", "b2b",
+        "https://justjoin.it/job-offer/jj-1", "justjoin");
+    JobReport report = new JobReport(
+        offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
+        List.of("on-call"), List.of("remote"), "system design", 8,
+        new SalaryRange(12000, 18000, "PLN"));
+
+    repo.saveJobs("2026-07-04", List.of(report));
+    assertThat(repo.loadJobs("2026-07-04")).containsExactly(report);
+  }
+
+  @Test
+  void loadJobsReturnsEmptyWhenMissing() {
+    assertThat(repo.loadJobs("2026-01-01")).isEmpty();
+  }
+
+  @Test
+  void analyticsRoundTrip() {
+    Analytics analytics = new Analytics(
+        "2026-07-04", 42, Map.of("Java", 30, "Spring", 20), List.of("Acme"),
+        new SalaryRange(10000, 30000, "PLN"), Map.of("product", 0.6), 66.7);
+
+    repo.saveAnalytics("2026-07-04", analytics);
+    assertThat(repo.loadAnalytics("2026-07-04")).isEqualTo(analytics);
+  }
+
+  @Test
+  void saveCreatesDateDirectory() {
+    repo.saveAnalytics("2026-07-04",
+        new Analytics("2026-07-04", 1, Map.of(), List.of(), null, Map.of(), 0.0));
+    assertThat(Files.isDirectory(tmp.resolve("data").resolve("2026-07-04"))).isTrue();
+  }
+
+  @Test
+  void listDatesReturnsOnlyDateDirectoriesSorted() throws Exception {
+    repo.saveAnalytics("2026-07-06",
+        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+    repo.saveAnalytics("2026-07-04",
+        new Analytics("2026-07-04", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+    // noise that must be ignored
+    Files.createDirectories(tmp.resolve("data").resolve("not-a-date"));
+    repo.writeProfile(new UserProfile(List.of(), 0, null, false, 0, "PLN", null, List.of(), 0));
+
+    assertThat(repo.listDates()).containsExactly("2026-07-04", "2026-07-06");
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.repository.JsonRepository` (Spring `@Component`) for all disk I/O — no database, JSON only
- Methods: `readProfile`/`writeProfile`, `readSeenIds`/`appendSeenIds` (dedup), `saveJobs`/`loadJobs`, `saveAnalytics`/`loadAnalytics`, `listDates`
- Configurable data dir via `radar.data.dir` (default `data`); auto-creates the data dir and per-date dirs; pretty-prints for human inspection
- Thread-safe via `ReentrantReadWriteLock`; `appendSeenIds` does a locked read-modify-write and drops duplicates

## Test plan
- `./gradlew build` green; 9 tests cover round-trips for every method, auto dir creation, seen-id dedup across appends, and `listDates` filtering to `YYYY-MM-DD` dirs only

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)