### PR TITLE
feat(VR-7): ScraperService

### DIFF
--- a/src/main/java/radar/service/ScraperService.java
+++ b/src/main/java/radar/service/ScraperService.java
@@ -1,0 +1,40 @@
+package radar.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import radar.connector.JustJoinConnector;
+import radar.model.RawJobOffer;
+import radar.repository.JsonRepository;
+
+/**
+ * Orchestrates scraping: fetches all offers from the connector and filters out the ones already
+ * processed (tracked in {@code seen-ids.json}). Seen ids are only persisted after enrichment
+ * succeeds, so {@link #markAsSeen(List)} is a separate step the caller invokes at the end of a scan.
+ */
+@Service
+public class ScraperService {
+
+  private final JustJoinConnector connector;
+  private final JsonRepository repository;
+
+  public ScraperService(JustJoinConnector connector, JsonRepository repository) {
+    this.connector = connector;
+    this.repository = repository;
+  }
+
+  /** Returns only offers whose id has not been seen before. Does not persist anything. */
+  public List<RawJobOffer> scrapeNew() {
+    List<RawJobOffer> all = connector.fetchAll();
+    Set<String> seen = new HashSet<>(repository.readSeenIds());
+    return all.stream()
+        .filter(offer -> !seen.contains(offer.id()))
+        .toList();
+  }
+
+  /** Records the given offer ids as processed so they are skipped on the next scan. */
+  public void markAsSeen(List<String> ids) {
+    repository.appendSeenIds(ids);
+  }
+}

--- a/src/test/java/radar/service/ScraperServiceTest.java
+++ b/src/test/java/radar/service/ScraperServiceTest.java
@@ -1,0 +1,62 @@
+package radar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import radar.connector.JustJoinConnector;
+import radar.model.RawJobOffer;
+import radar.repository.JsonRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ScraperServiceTest {
+
+  @Mock
+  JustJoinConnector connector;
+
+  @Mock
+  JsonRepository repository;
+
+  @InjectMocks
+  ScraperService scraperService;
+
+  private RawJobOffer offer(String id) {
+    return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
+        null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
+        "justjoin");
+  }
+
+  @Test
+  void scrapeNewFiltersOutSeenOffers() {
+    List<RawJobOffer> all = IntStream.rangeClosed(1, 10).mapToObj(i -> offer("id-" + i)).toList();
+    when(connector.fetchAll()).thenReturn(all);
+    when(repository.readSeenIds()).thenReturn(List.of("id-2", "id-5", "id-9"));
+
+    List<RawJobOffer> result = scraperService.scrapeNew();
+
+    assertThat(result).hasSize(7);
+    assertThat(result).extracting(RawJobOffer::id)
+        .containsExactly("id-1", "id-3", "id-4", "id-6", "id-7", "id-8", "id-10");
+  }
+
+  @Test
+  void scrapeNewReturnsAllWhenNothingSeen() {
+    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
+    when(repository.readSeenIds()).thenReturn(List.of());
+
+    assertThat(scraperService.scrapeNew()).extracting(RawJobOffer::id).containsExactly("a", "b");
+  }
+
+  @Test
+  void markAsSeenDelegatesToRepository() {
+    scraperService.markAsSeen(List.of("x", "y"));
+    verify(repository).appendSeenIds(List.of("x", "y"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.service.ScraperService` orchestrating the scrape step
- `scrapeNew()` = `JustJoinConnector.fetchAll()` filtered against `seen-ids.json` (returns only new offers, persists nothing)
- `markAsSeen(ids)` appends processed ids via `JsonRepository` — a separate step so ids are only recorded after enrichment succeeds

## Test plan
- `./gradlew build` green; mock-based tests: 10 offers with 3 seen → 7 returned; all-new passthrough; `markAsSeen` delegates to the repository

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)