### PR TITLE
feat(VR-8): EnricherService

### DIFF
--- a/src/main/java/radar/config/AnthropicConfig.java
+++ b/src/main/java/radar/config/AnthropicConfig.java
@@ -1,0 +1,20 @@
+package radar.config;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Exposes the Anthropic client as a Spring bean, configured from {@code anthropic.api.key}
+ * (which resolves to the {@code ANTHROPIC_API_KEY} environment variable).
+ */
+@Configuration
+public class AnthropicConfig {
+
+  @Bean
+  public AnthropicClient anthropicClient(@Value("${anthropic.api.key:}") String apiKey) {
+    return AnthropicOkHttpClient.builder().apiKey(apiKey).build();
+  }
+}

--- a/src/main/java/radar/service/EnricherService.java
+++ b/src/main/java/radar/service/EnricherService.java
@@ -1,0 +1,129 @@
+package radar.service;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.StructuredMessage;
+import com.anthropic.models.messages.StructuredMessageCreateParams;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.springframework.stereotype.Service;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.ScanProgress;
+import radar.model.UserProfile;
+
+/**
+ * Enriches a {@link RawJobOffer} into a {@link JobReport} using Claude Haiku via the Anthropic Java
+ * SDK's structured-output support: the request declares {@link EnrichmentResult} as the output type,
+ * so Claude returns strictly-typed JSON matching that schema.
+ *
+ * <p>Only plain text is ever sent to Claude — never raw HTML (see {@code .claude/rules/claude-api.md}).
+ * Filtering by {@code minMatchScore} happens upstream, not here.
+ */
+@Service
+public class EnricherService {
+
+  private static final String MODEL = "claude-haiku-4-5-20251001";
+  private static final long MAX_TOKENS = 2048L;
+  private static final int MIN_SCORE = 1;
+  private static final int MAX_SCORE = 10;
+
+  private final AnthropicClient client;
+  private final ObjectMapper objectMapper;
+
+  public EnricherService(AnthropicClient client, ObjectMapper objectMapper) {
+    this.client = client;
+    this.objectMapper = objectMapper;
+  }
+
+  /** Enriches a single offer against the user's profile. */
+  public JobReport enrich(RawJobOffer offer, UserProfile profile) {
+    EnrichmentResult result = requestEnrichment(buildPrompt(offer, profile));
+    return toReport(result, offer);
+  }
+
+  /**
+   * Enriches every offer, emitting an {@code ENRICHING} progress event per offer. Returns all
+   * reports (including low-scoring ones — filtering happens upstream).
+   */
+  public List<JobReport> enrichAll(List<RawJobOffer> offers, UserProfile profile,
+      Consumer<ScanProgress> progressCallback) {
+    List<JobReport> reports = new ArrayList<>();
+    int total = offers.size();
+    for (int i = 0; i < total; i++) {
+      RawJobOffer offer = offers.get(i);
+      reports.add(enrich(offer, profile));
+      progressCallback.accept(new ScanProgress(
+          ScanProgress.Type.ENRICHING, "Enriched " + offer.title(), i + 1, total, null));
+    }
+    return reports;
+  }
+
+  /**
+   * Calls Claude Haiku with structured output and returns the parsed result. Package-private and
+   * overridable so tests can exercise the surrounding logic without hitting the network.
+   */
+  EnrichmentResult requestEnrichment(String prompt) {
+    StructuredMessageCreateParams<EnrichmentResult> params = MessageCreateParams.builder()
+        .model(MODEL)
+        .maxTokens(MAX_TOKENS)
+        .outputConfig(EnrichmentResult.class)
+        .addUserMessage(prompt)
+        .build();
+    StructuredMessage<EnrichmentResult> message = client.messages().create(params);
+    return message.content().stream()
+        .flatMap(block -> block.text().stream())
+        .map(text -> text.text())
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Claude returned no structured content"));
+  }
+
+  /** Builds the plain-text prompt. Package-private for testing (asserts no HTML leaks in). */
+  String buildPrompt(RawJobOffer offer, UserProfile profile) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("You are a career advisor. Analyse the following job offer for this candidate ")
+        .append("and score how well it matches their profile on a scale of 1 to 10.\n\n");
+    sb.append("=== CANDIDATE PROFILE (JSON) ===\n").append(writeJson(profile)).append("\n\n");
+    sb.append("=== JOB OFFER ===\n");
+    append(sb, "Title", offer.title());
+    append(sb, "Company", offer.companyName());
+    append(sb, "Location", offer.location());
+    append(sb, "Remote", offer.remote() == null ? null : offer.remote().toString());
+    append(sb, "Experience level", offer.experienceLevel());
+    append(sb, "Contract type", offer.contractType());
+    if (offer.skills() != null && !offer.skills().isEmpty()) {
+      append(sb, "Listed skills", String.join(", ", offer.skills()));
+    }
+    if (offer.salaryMin() != null || offer.salaryMax() != null) {
+      append(sb, "Salary", offer.salaryMin() + " - " + offer.salaryMax() + " " + offer.currency());
+    }
+    if (offer.description() != null && !offer.description().isBlank()) {
+      append(sb, "Description", offer.description());
+    }
+    return sb.toString();
+  }
+
+  /** Maps the model's result onto a JobReport, clamping the score to the valid 1-10 range. */
+  JobReport toReport(EnrichmentResult r, RawJobOffer offer) {
+    int score = Math.max(MIN_SCORE, Math.min(MAX_SCORE, r.matchScore()));
+    return new JobReport(offer, r.keySkills(), r.niceToHave(), r.projectType(), r.realSeniority(),
+        r.redFlags(), r.greenFlags(), r.interviewFocus(), score, r.salary());
+  }
+
+  private static void append(StringBuilder sb, String label, String value) {
+    if (value != null && !value.isBlank()) {
+      sb.append(label).append(": ").append(value).append('\n');
+    }
+  }
+
+  private String writeJson(UserProfile profile) {
+    try {
+      return objectMapper.writeValueAsString(profile);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize profile for prompt", e);
+    }
+  }
+}

--- a/src/main/java/radar/service/EnrichmentResult.java
+++ b/src/main/java/radar/service/EnrichmentResult.java
@@ -1,0 +1,34 @@
+package radar.service;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+import radar.model.SalaryRange;
+
+/**
+ * The structured JSON Claude Haiku returns for a single offer — every {@link radar.model.JobReport}
+ * field except the raw offer, which the enricher attaches afterwards. Field descriptions are sent to
+ * the model as part of the derived JSON schema, so keep them instructive.
+ */
+@JsonClassDescription("Analysis of a single job offer relative to the user's profile.")
+public record EnrichmentResult(
+    @JsonPropertyDescription("The core technologies the role genuinely requires day-to-day.")
+    List<String> keySkills,
+    @JsonPropertyDescription("Skills that are a bonus but not required.")
+    List<String> niceToHave,
+    @JsonPropertyDescription("Type of work, e.g. product, outsourcing, consulting, startup.")
+    String projectType,
+    @JsonPropertyDescription("The real seniority the role demands: junior, mid, senior, or lead.")
+    String realSeniority,
+    @JsonPropertyDescription("Concerning signals: vague scope, unrealistic stack, low pay, churn.")
+    List<String> redFlags,
+    @JsonPropertyDescription("Positive signals: clear tech, good pay, remote, strong team.")
+    List<String> greenFlags,
+    @JsonPropertyDescription("What the candidate should prepare for interviews at this role.")
+    String interviewFocus,
+    @JsonPropertyDescription("How well the offer matches the user's profile, from 1 (poor) to 10 (excellent).")
+    int matchScore,
+    @JsonPropertyDescription("The offer's salary range as understood from the posting.")
+    SalaryRange salary
+) {
+}

--- a/src/test/java/radar/service/EnricherServiceTest.java
+++ b/src/test/java/radar/service/EnricherServiceTest.java
@@ -1,0 +1,129 @@
+package radar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.anthropic.client.AnthropicClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.ScanProgress;
+import radar.model.SalaryRange;
+import radar.model.UserProfile;
+
+class EnricherServiceTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private final UserProfile profile = new UserProfile(
+      List.of("Java", "Spring Boot"), 3, "B2B", true, 15000, "PLN", "B2B",
+      List.of("Kraków", "Remote"), 6);
+
+  private RawJobOffer offer(String id, String title) {
+    return new RawJobOffer(id, title, "Acme", null, "Kraków", true, "2026-07-04", "senior",
+        null, List.of("Java", "AWS"), 18000, 26000, "PLN", "b2b",
+        "https://justjoin.it/job-offer/" + id, "justjoin");
+  }
+
+  /**
+   * An EnricherService whose Claude call is replaced by parsing a canned JSON string — exercising
+   * the real prompt building, JSON→EnrichmentResult mapping, and toReport logic without the network.
+   */
+  private EnricherService withCannedJson(String json) {
+    return new EnricherService(mock(AnthropicClient.class), mapper) {
+      @Override
+      EnrichmentResult requestEnrichment(String prompt) {
+        try {
+          return mapper.readValue(json, EnrichmentResult.class);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  @Test
+  void validJsonProducesJobReportWithOfferAttached() {
+    String json = """
+        {
+          "keySkills": ["Java", "Spring Boot"],
+          "niceToHave": ["Kafka"],
+          "projectType": "product",
+          "realSeniority": "senior",
+          "redFlags": ["on-call"],
+          "greenFlags": ["remote", "clear stack"],
+          "interviewFocus": "system design",
+          "matchScore": 8,
+          "salary": {"min": 18000, "max": 26000, "currency": "PLN"}
+        }
+        """;
+    RawJobOffer o = offer("jj-1", "Senior Java Dev");
+
+    JobReport report = withCannedJson(json).enrich(o, profile);
+
+    assertThat(report.rawJobOffer()).isSameAs(o);
+    assertThat(report.keySkills()).containsExactly("Java", "Spring Boot");
+    assertThat(report.niceToHave()).containsExactly("Kafka");
+    assertThat(report.projectType()).isEqualTo("product");
+    assertThat(report.realSeniority()).isEqualTo("senior");
+    assertThat(report.redFlags()).containsExactly("on-call");
+    assertThat(report.greenFlags()).containsExactly("remote", "clear stack");
+    assertThat(report.interviewFocus()).isEqualTo("system design");
+    assertThat(report.matchScore()).isEqualTo(8);
+    assertThat(report.salary()).isEqualTo(new SalaryRange(18000, 26000, "PLN"));
+  }
+
+  @Test
+  void matchScoreIsClampedIntoOneToTenRange() {
+    EnricherService svc = new EnricherService(mock(AnthropicClient.class), mapper);
+    RawJobOffer o = offer("jj-1", "Java Dev");
+
+    EnrichmentResult tooHigh = result(15);
+    EnrichmentResult tooLow = result(0);
+
+    assertThat(svc.toReport(tooHigh, o).matchScore()).isEqualTo(10);
+    assertThat(svc.toReport(tooLow, o).matchScore()).isEqualTo(1);
+    assertThat(svc.toReport(result(7), o).matchScore()).isEqualTo(7);
+  }
+
+  @Test
+  void enrichAllEmitsOneEnrichingProgressPerOffer() {
+    String json = """
+        {"keySkills":[],"niceToHave":[],"projectType":"product","realSeniority":"mid",
+         "redFlags":[],"greenFlags":[],"interviewFocus":"basics","matchScore":5,
+         "salary":{"min":10000,"max":15000,"currency":"PLN"}}
+        """;
+    EnricherService svc = withCannedJson(json);
+    List<RawJobOffer> offers = List.of(offer("a", "A"), offer("b", "B"), offer("c", "C"));
+    List<ScanProgress> events = new ArrayList<>();
+
+    List<JobReport> reports = svc.enrichAll(offers, profile, events::add);
+
+    assertThat(reports).hasSize(3);
+    assertThat(events).hasSize(3);
+    assertThat(events).allMatch(e -> e.type() == ScanProgress.Type.ENRICHING);
+    assertThat(events).extracting(ScanProgress::current).containsExactly(1, 2, 3);
+    assertThat(events).allMatch(e -> e.total() == 3);
+  }
+
+  @Test
+  void promptContainsProfileAndOfferAndNoHtml() {
+    EnricherService svc = new EnricherService(mock(AnthropicClient.class), mapper);
+    RawJobOffer o = offer("jj-1", "Senior Java Dev");
+
+    String prompt = svc.buildPrompt(o, profile);
+
+    assertThat(prompt).contains("Senior Java Dev").contains("Acme").contains("Kraków");
+    assertThat(prompt).contains("Spring Boot"); // from profile JSON
+    assertThat(prompt).contains("18000").contains("26000");
+    assertThat(prompt).doesNotContain("<").doesNotContain(">"); // plain text only, never HTML
+  }
+
+  private EnrichmentResult result(int score) {
+    return new EnrichmentResult(List.of("Java"), List.of(), "product", "mid", List.of(), List.of(),
+        "focus", score, new SalaryRange(10000, 20000, "PLN"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.service.EnricherService` enriching a `RawJobOffer` → `JobReport` via Claude Haiku (`claude-haiku-4-5-20251001`)
- Uses the **Anthropic Java SDK structured output** (`outputConfig(EnrichmentResult.class)`) so Claude returns strictly-typed JSON matching the schema
- Only plain text is sent to Claude — never HTML; `matchScore` clamped to 1–10; `enrichAll` emits one `ENRICHING` progress event per offer and does **not** filter by `minMatchScore`
- Adds `AnthropicConfig` (`AnthropicClient` bean from `anthropic.api.key`)
- The Claude call is isolated behind an overridable method so unit tests exercise prompt-building, JSON→JobReport mapping, score clamping, and the progress callback without the network

## Test plan
- `./gradlew build` green; 4 tests: valid JSON → JobReport (offer attached), score clamp (0→1, 15→10), one progress event per offer, prompt contains profile+offer and no HTML

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)