### PR TITLE
feat(VR-9): ReporterService

### DIFF
--- a/src/main/java/radar/service/ReporterService.java
+++ b/src/main/java/radar/service/ReporterService.java
@@ -1,0 +1,143 @@
+package radar.service;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.SalaryRange;
+import radar.repository.JsonRepository;
+
+/**
+ * Aggregates {@link Analytics} across ALL scanned offers for a date (before any match-score filter),
+ * and computes cross-snapshot skill trends. Does not scrape, call Claude, or filter by score.
+ */
+@Service
+public class ReporterService {
+
+  private static final int TOP_COMPANIES = 10;
+
+  private final JsonRepository repository;
+
+  public ReporterService(JsonRepository repository) {
+    this.repository = repository;
+  }
+
+  /** Builds the analytics snapshot for a date from every enriched report (no score filtering). */
+  public Analytics buildAnalytics(String date, List<JobReport> allReports) {
+    int total = allReports.size();
+    return new Analytics(
+        date,
+        total,
+        skillFrequency(allReports),
+        topCompanies(allReports),
+        salaryDistribution(allReports),
+        projectTypeBreakdown(allReports, total),
+        remotePercentage(allReports, total));
+  }
+
+  /**
+   * Merges {@code skillFrequency} across every saved snapshot, summing counts per skill, sorted by
+   * total frequency descending.
+   */
+  public Map<String, Integer> computeTrends() {
+    Map<String, Integer> merged = new HashMap<>();
+    for (String date : repository.listDates()) {
+      Analytics analytics;
+      try {
+        analytics = repository.loadAnalytics(date);
+      } catch (RuntimeException e) {
+        continue; // a date dir without analytics.json — skip it
+      }
+      if (analytics.skillFrequency() != null) {
+        analytics.skillFrequency().forEach((skill, count) -> merged.merge(skill, count, Integer::sum));
+      }
+    }
+    return sortByValueDesc(merged);
+  }
+
+  private Map<String, Integer> skillFrequency(List<JobReport> reports) {
+    Map<String, Integer> counts = new HashMap<>();
+    for (JobReport report : reports) {
+      if (report.keySkills() != null) {
+        for (String skill : report.keySkills()) {
+          counts.merge(skill, 1, Integer::sum);
+        }
+      }
+    }
+    return sortByValueDesc(counts);
+  }
+
+  private List<String> topCompanies(List<JobReport> reports) {
+    Map<String, Integer> counts = new HashMap<>();
+    for (JobReport report : reports) {
+      String company = report.rawJobOffer() == null ? null : report.rawJobOffer().companyName();
+      if (company != null && !company.isBlank()) {
+        counts.merge(company, 1, Integer::sum);
+      }
+    }
+    return counts.entrySet().stream()
+        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .limit(TOP_COMPANIES)
+        .map(Map.Entry::getKey)
+        .toList();
+  }
+
+  private SalaryRange salaryDistribution(List<JobReport> reports) {
+    List<Integer> mins = reports.stream()
+        .map(JobReport::salary)
+        .filter(s -> s != null && s.min() != null)
+        .map(SalaryRange::min)
+        .sorted()
+        .toList();
+    if (mins.isEmpty()) {
+      return new SalaryRange(null, null, null);
+    }
+    String currency = reports.stream()
+        .map(JobReport::salary)
+        .filter(s -> s != null && s.currency() != null)
+        .map(SalaryRange::currency)
+        .findFirst()
+        .orElse(null);
+    return new SalaryRange(mins.get(0), mins.get(mins.size() - 1), currency);
+  }
+
+  private Map<String, Double> projectTypeBreakdown(List<JobReport> reports, int total) {
+    if (total == 0) {
+      return new LinkedHashMap<>();
+    }
+    Map<String, Long> counts = reports.stream()
+        .map(JobReport::projectType)
+        .filter(t -> t != null && !t.isBlank())
+        .collect(Collectors.groupingBy(t -> t, Collectors.counting()));
+    LinkedHashMap<String, Double> breakdown = new LinkedHashMap<>();
+    counts.entrySet().stream()
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+        .forEach(e -> breakdown.put(e.getKey(), e.getValue() * 100.0 / total));
+    return breakdown;
+  }
+
+  private double remotePercentage(List<JobReport> reports, int total) {
+    if (total == 0) {
+      return 0.0;
+    }
+    long remote = reports.stream()
+        .map(JobReport::rawJobOffer)
+        .filter(o -> o != null && Boolean.TRUE.equals(o.remote()))
+        .count();
+    return remote * 100.0 / total;
+  }
+
+  private static Map<String, Integer> sortByValueDesc(Map<String, Integer> counts) {
+    LinkedHashMap<String, Integer> sorted = new LinkedHashMap<>();
+    counts.entrySet().stream()
+        .sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(Map.Entry::getValue).reversed()
+            .thenComparing(Map.Entry::getKey))
+        .forEach(e -> sorted.put(e.getKey(), e.getValue()));
+    return sorted;
+  }
+}

--- a/src/test/java/radar/service/ReporterServiceTest.java
+++ b/src/test/java/radar/service/ReporterServiceTest.java
@@ -1,0 +1,145 @@
+package radar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.SalaryRange;
+import radar.repository.JsonRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReporterServiceTest {
+
+  @Mock
+  JsonRepository repository;
+
+  @InjectMocks
+  ReporterService reporter;
+
+  private JobReport report(String company, boolean remote, String projectType, Integer salaryMin,
+      List<String> keySkills) {
+    RawJobOffer offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
+        "Kraków", remote, "2026-07-04", "senior", null, keySkills, salaryMin,
+        salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin");
+    return new JobReport(offer, keySkills, List.of(), projectType, "senior", List.of(), List.of(),
+        "focus", 7, new SalaryRange(salaryMin, salaryMin == null ? null : salaryMin + 5000, "PLN"));
+  }
+
+  @Test
+  void skillFrequencyCountsAndSortsDescending() {
+    List<JobReport> reports = List.of(
+        report("A", true, "product", 10000, List.of("Java", "Spring")),
+        report("B", true, "product", 12000, List.of("Java", "AWS")),
+        report("C", false, "outsourcing", 11000, List.of("Java", "Spring")),
+        report("D", true, "product", 13000, List.of("Java")),
+        report("E", false, "product", 9000, List.of("SQL")));
+
+    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+
+    assertThat(analytics.totalScanned()).isEqualTo(5);
+    assertThat(analytics.skillFrequency())
+        .containsExactly(
+            Map.entry("Java", 4),
+            Map.entry("Spring", 2),
+            Map.entry("AWS", 1),
+            Map.entry("SQL", 1));
+    // Java first (highest count); ties broken alphabetically
+    assertThat(analytics.skillFrequency().keySet().iterator().next()).isEqualTo("Java");
+  }
+
+  @Test
+  void remotePercentageIsBetweenZeroAndHundred() {
+    List<JobReport> reports = List.of(
+        report("A", true, "product", 10000, List.of("Java")),
+        report("B", true, "product", 12000, List.of("Java")),
+        report("C", false, "product", 11000, List.of("Java")),
+        report("D", false, "product", 13000, List.of("Java")));
+
+    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+
+    assertThat(analytics.remotePercentage()).isBetween(0.0, 100.0).isEqualTo(50.0);
+  }
+
+  @Test
+  void topCompaniesRankedByOfferCount() {
+    List<JobReport> reports = List.of(
+        report("Acme", true, "product", 10000, List.of("Java")),
+        report("Acme", true, "product", 12000, List.of("Java")),
+        report("Acme", true, "product", 12000, List.of("Java")),
+        report("Globex", false, "product", 11000, List.of("Java")),
+        report("Initech", false, "product", 9000, List.of("Java")));
+
+    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+
+    assertThat(analytics.topCompanies()).first().isEqualTo("Acme");
+    assertThat(analytics.topCompanies()).containsExactlyInAnyOrder("Acme", "Globex", "Initech");
+  }
+
+  @Test
+  void salaryDistributionUsesMinAndMaxOfSalaryMins() {
+    List<JobReport> reports = List.of(
+        report("A", true, "product", 9000, List.of("Java")),
+        report("B", true, "product", 18000, List.of("Java")),
+        report("C", false, "product", 12000, List.of("Java")));
+
+    SalaryRange dist = reporter.buildAnalytics("2026-07-04", reports).salaryDistribution();
+
+    assertThat(dist.min()).isEqualTo(9000);
+    assertThat(dist.max()).isEqualTo(18000);
+    assertThat(dist.currency()).isEqualTo("PLN");
+  }
+
+  @Test
+  void projectTypeBreakdownSumsToAround100Percent() {
+    List<JobReport> reports = List.of(
+        report("A", true, "product", 10000, List.of("Java")),
+        report("B", true, "product", 12000, List.of("Java")),
+        report("C", false, "outsourcing", 11000, List.of("Java")),
+        report("D", true, "product", 13000, List.of("Java")));
+
+    Map<String, Double> breakdown = reporter.buildAnalytics("2026-07-04", reports)
+        .projectTypeBreakdown();
+
+    assertThat(breakdown.get("product")).isEqualTo(75.0);
+    assertThat(breakdown.get("outsourcing")).isEqualTo(25.0);
+    assertThat(breakdown.values().stream().mapToDouble(Double::doubleValue).sum()).isEqualTo(100.0);
+  }
+
+  @Test
+  void computeTrendsMergesSkillFrequencyAcrossSnapshots() {
+    when(repository.listDates()).thenReturn(List.of("2026-07-04", "2026-07-05"));
+    when(repository.loadAnalytics("2026-07-04")).thenReturn(analytics(Map.of("Java", 3, "Spring", 2)));
+    when(repository.loadAnalytics("2026-07-05")).thenReturn(analytics(Map.of("Java", 5, "AWS", 1)));
+
+    Map<String, Integer> trends = reporter.computeTrends();
+
+    assertThat(trends).isNotEmpty();
+    assertThat(trends).containsExactly(
+        Map.entry("Java", 8),
+        Map.entry("Spring", 2),
+        Map.entry("AWS", 1));
+  }
+
+  @Test
+  void computeTrendsSkipsDatesWithoutAnalytics() {
+    when(repository.listDates()).thenReturn(List.of("2026-07-04", "2026-07-05"));
+    when(repository.loadAnalytics("2026-07-04")).thenReturn(analytics(Map.of("Java", 2)));
+    when(repository.loadAnalytics("2026-07-05"))
+        .thenThrow(new IllegalStateException("File not found"));
+
+    assertThat(reporter.computeTrends()).containsExactly(Map.entry("Java", 2));
+  }
+
+  private Analytics analytics(Map<String, Integer> skills) {
+    return new Analytics("2026-07-04", 0, skills, List.of(), null, Map.of(), 0.0);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.service.ReporterService`
- `buildAnalytics(date, allReports)` aggregates across ALL reports (no `minMatchScore` filter): skill frequency (sorted desc, ties alphabetical), top-10 companies by offer count, salary min/max, project-type breakdown as %, and remote %
- `computeTrends()` merges `skillFrequency` across every saved snapshot via `JsonRepository.listDates()`/`loadAnalytics`, summing per skill and skipping date dirs without an `analytics.json`

## Test plan
- `./gradlew build` green; 7 tests: 5 reports → skill counts, remote % in 0–100 (=50), top companies ranking, salary min/max, project-type % sums to 100, trends merge across snapshots, and trends skip missing analytics

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)