### PR TITLE
feat(VR-10): Scan Orchestration

### DIFF
--- a/src/main/java/radar/service/ScanService.java
+++ b/src/main/java/radar/service/ScanService.java
@@ -1,0 +1,94 @@
+package radar.service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.ScanProgress;
+import radar.model.UserProfile;
+import radar.repository.JsonRepository;
+
+/**
+ * Orchestrates a full scan: scrape → enrich → aggregate analytics → filter → persist, streaming
+ * {@link ScanProgress} events to the caller's {@link SseEmitter} as it goes. Runs asynchronously so
+ * the HTTP request returns immediately.
+ */
+@Service
+public class ScanService {
+
+  private final ScraperService scraperService;
+  private final EnricherService enricherService;
+  private final ReporterService reporterService;
+  private final JsonRepository repository;
+
+  public ScanService(ScraperService scraperService, EnricherService enricherService,
+      ReporterService reporterService, JsonRepository repository) {
+    this.scraperService = scraperService;
+    this.enricherService = enricherService;
+    this.reporterService = reporterService;
+    this.repository = repository;
+  }
+
+  /** Launches the scan asynchronously and returns immediately. */
+  public void startScan(SseEmitter emitter) {
+    CompletableFuture.runAsync(() -> runScan(emitter));
+  }
+
+  /**
+   * The scan body. Package-private and synchronous so it can be unit-tested directly; {@link
+   * #startScan} wraps it in a background task.
+   */
+  void runScan(SseEmitter emitter) {
+    try {
+      String date = LocalDate.now().toString();
+      UserProfile profile = repository.readProfile();
+
+      emit(emitter, new ScanProgress(ScanProgress.Type.SCANNING, "Scanning offers", null, null, null));
+      List<RawJobOffer> newOffers = scraperService.scrapeNew();
+      emit(emitter, new ScanProgress(
+          ScanProgress.Type.SCANNING, "Found new offers", 0, newOffers.size(), null));
+
+      List<JobReport> allReports =
+          enricherService.enrichAll(newOffers, profile, progress -> emit(emitter, progress));
+
+      Analytics analytics = reporterService.buildAnalytics(date, allReports);
+      int minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
+      List<JobReport> filtered = allReports.stream()
+          .filter(report -> report.matchScore() >= minScore)
+          .toList();
+
+      emit(emitter, new ScanProgress(
+          ScanProgress.Type.SAVING, "Saving results", null, null, filtered.size()));
+      repository.saveJobs(date, filtered);
+      repository.saveAnalytics(date, analytics);
+      scraperService.markAsSeen(newOffers.stream().map(RawJobOffer::id).toList());
+
+      emit(emitter, new ScanProgress(
+          ScanProgress.Type.DONE, "Scan complete", newOffers.size(), newOffers.size(),
+          filtered.size()));
+      emitter.complete();
+    } catch (Exception e) {
+      try {
+        emit(emitter, new ScanProgress(ScanProgress.Type.ERROR, e.getMessage(), null, null, null));
+      } catch (RuntimeException ignored) {
+        // the stream is already broken; fall through to completeWithError
+      }
+      emitter.completeWithError(e);
+    }
+  }
+
+  /** Sends one progress event over SSE. Package-private/overridable so tests can observe the stream. */
+  void emit(SseEmitter emitter, ScanProgress progress) {
+    try {
+      emitter.send(SseEmitter.event().data(progress));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to emit scan progress", e);
+    }
+  }
+}

--- a/src/test/java/radar/service/ScanServiceTest.java
+++ b/src/test/java/radar/service/ScanServiceTest.java
@@ -1,0 +1,142 @@
+package radar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import radar.model.Analytics;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.ScanProgress;
+import radar.model.SalaryRange;
+import radar.model.UserProfile;
+import radar.repository.JsonRepository;
+
+class ScanServiceTest {
+
+  private ScraperService scraper;
+  private EnricherService enricher;
+  private ReporterService reporter;
+  private JsonRepository repository;
+  private SseEmitter emitter;
+  private List<ScanProgress> emitted;
+  private ScanService scanService;
+
+  private final UserProfile profile = new UserProfile(
+      List.of("Java"), 3, "B2B", true, 15000, "PLN", "B2B", List.of("Kraków"), 6);
+
+  @BeforeEach
+  void setUp() {
+    scraper = mock(ScraperService.class);
+    enricher = mock(EnricherService.class);
+    reporter = mock(ReporterService.class);
+    repository = mock(JsonRepository.class);
+    emitter = mock(SseEmitter.class);
+    emitted = new ArrayList<>();
+    // capture the event stream by overriding emit; still exercise complete()/completeWithError()
+    scanService = new ScanService(scraper, enricher, reporter, repository) {
+      @Override
+      void emit(SseEmitter e, ScanProgress progress) {
+        emitted.add(progress);
+      }
+    };
+  }
+
+  private RawJobOffer offer(String id) {
+    return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "senior",
+        null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin");
+  }
+
+  private JobReport report(RawJobOffer offer, int score) {
+    return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
+        List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));
+  }
+
+  @Test
+  void runScanEmitsEventsInOrderAndPersistsFilteredResults() {
+    RawJobOffer a = offer("a");
+    RawJobOffer b = offer("b");
+    JobReport good = report(a, 8); // >= minMatchScore 6
+    JobReport weak = report(b, 4); // filtered out
+    Analytics analytics = new Analytics("2026-07-04", 2, java.util.Map.of("Java", 2), List.of(),
+        null, java.util.Map.of(), 100.0);
+
+    when(repository.readProfile()).thenReturn(profile);
+    when(scraper.scrapeNew()).thenReturn(List.of(a, b));
+    when(enricher.enrichAll(anyList(), eq(profile), any())).thenAnswer(inv -> {
+      Consumer<ScanProgress> cb = inv.getArgument(2);
+      cb.accept(new ScanProgress(ScanProgress.Type.ENRICHING, "Enriched a", 1, 2, null));
+      cb.accept(new ScanProgress(ScanProgress.Type.ENRICHING, "Enriched b", 2, 2, null));
+      return List.of(good, weak);
+    });
+    when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
+
+    scanService.runScan(emitter);
+
+    // event order: SCANNING, SCANNING, ENRICHING, ENRICHING, SAVING, DONE
+    assertThat(emitted).extracting(ScanProgress::type).containsExactly(
+        ScanProgress.Type.SCANNING, ScanProgress.Type.SCANNING,
+        ScanProgress.Type.ENRICHING, ScanProgress.Type.ENRICHING,
+        ScanProgress.Type.SAVING, ScanProgress.Type.DONE);
+
+    // only the offer meeting minMatchScore is saved as jobs; analytics saved regardless
+    ArgumentCaptor<List<JobReport>> jobs = ArgumentCaptor.forClass(List.class);
+    verify(repository).saveJobs(anyString(), jobs.capture());
+    assertThat(jobs.getValue()).containsExactly(good);
+    verify(repository).saveAnalytics(anyString(), eq(analytics));
+    verify(scraper).markAsSeen(List.of("a", "b"));
+    verify(emitter).complete();
+
+    ScanProgress done = emitted.get(emitted.size() - 1);
+    assertThat(done.saved()).isEqualTo(1);
+    assertThat(done.total()).isEqualTo(2);
+  }
+
+  @Test
+  void runScanSavesAnalyticsEvenWhenNothingPassesFilter() {
+    RawJobOffer a = offer("a");
+    JobReport weak = report(a, 3);
+    Analytics analytics = new Analytics("2026-07-04", 1, java.util.Map.of(), List.of(), null,
+        java.util.Map.of(), 100.0);
+
+    when(repository.readProfile()).thenReturn(profile);
+    when(scraper.scrapeNew()).thenReturn(List.of(a));
+    when(enricher.enrichAll(anyList(), any(), any())).thenReturn(List.of(weak));
+    when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
+
+    scanService.runScan(emitter);
+
+    ArgumentCaptor<List<JobReport>> jobs = ArgumentCaptor.forClass(List.class);
+    verify(repository).saveJobs(anyString(), jobs.capture());
+    assertThat(jobs.getValue()).isEmpty();
+    verify(repository).saveAnalytics(anyString(), eq(analytics));
+    verify(emitter).complete();
+  }
+
+  @Test
+  void runScanEmitsErrorAndCompletesWithErrorOnFailure() {
+    when(repository.readProfile()).thenReturn(profile);
+    RuntimeException boom = new RuntimeException("scrape failed");
+    when(scraper.scrapeNew()).thenThrow(boom);
+
+    scanService.runScan(emitter);
+
+    assertThat(emitted).extracting(ScanProgress::type)
+        .contains(ScanProgress.Type.ERROR)
+        .doesNotContain(ScanProgress.Type.DONE);
+    verify(emitter).completeWithError(boom);
+    verify(repository, org.mockito.Mockito.never()).saveJobs(anyString(), anyList());
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.service.ScanService` tying scraper → enricher → reporter → repository together
- `startScan(emitter)` runs asynchronously (`CompletableFuture`) and returns immediately
- `runScan` emits `ScanProgress` over the `SseEmitter` in order **SCANNING → ENRICHING → SAVING → DONE**, filters reports by `UserProfile.minMatchScore`, saves `jobs.json` (filtered) and `analytics.json` (all), marks offers seen, then completes the emitter
- Analytics are saved even when nothing passes the filter; on any failure it emits `ERROR` and calls `completeWithError`

## Test plan
- `./gradlew build` green; 3 tests: full-flow event order + filtered persistence + `markAsSeen` + `complete()`; analytics saved when filter yields nothing; error path emits `ERROR` and `completeWithError`, saves nothing

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)