### PR TITLE
feat(VR-11): REST Controllers + SSE

### DIFF
--- a/src/main/java/radar/config/JacksonConfig.java
+++ b/src/main/java/radar/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package radar.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides a Jackson 2 {@link ObjectMapper} bean. Spring Boot 4 auto-configures Jackson 3, so the
+ * {@code com.fasterxml.jackson.databind.ObjectMapper} our repository/connector/enricher use is not
+ * otherwise available for injection.
+ */
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ObjectMapper objectMapper() {
+    return new ObjectMapper();
+  }
+}

--- a/src/main/java/radar/web/AnalyticsController.java
+++ b/src/main/java/radar/web/AnalyticsController.java
@@ -1,0 +1,22 @@
+package radar.web;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import radar.service.ReporterService;
+
+/** Exposes cross-snapshot skill trends. */
+@RestController
+public class AnalyticsController {
+
+  private final ReporterService reporterService;
+
+  public AnalyticsController(ReporterService reporterService) {
+    this.reporterService = reporterService;
+  }
+
+  @GetMapping("/api/trends")
+  public Map<String, Integer> trends() {
+    return reporterService.computeTrends();
+  }
+}

--- a/src/main/java/radar/web/JobController.java
+++ b/src/main/java/radar/web/JobController.java
@@ -1,0 +1,41 @@
+package radar.web;
+
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import radar.model.JobReport;
+import radar.model.UserProfile;
+import radar.repository.JsonRepository;
+
+/**
+ * Serves saved job reports, filtered by the current profile's {@code minMatchScore}. Defaults to the
+ * most recent snapshot when no date is given.
+ */
+@RestController
+public class JobController {
+
+  private final JsonRepository repository;
+
+  public JobController(JsonRepository repository) {
+    this.repository = repository;
+  }
+
+  @GetMapping("/api/jobs")
+  public List<JobReport> jobs(@RequestParam(required = false) String date) {
+    String target = date != null ? date : latestDate();
+    if (target == null) {
+      return List.of();
+    }
+    UserProfile profile = repository.readProfile();
+    int minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
+    return repository.loadJobs(target).stream()
+        .filter(report -> report.matchScore() >= minScore)
+        .toList();
+  }
+
+  private String latestDate() {
+    List<String> dates = repository.listDates(); // ascending
+    return dates.isEmpty() ? null : dates.get(dates.size() - 1);
+  }
+}

--- a/src/main/java/radar/web/ProfileController.java
+++ b/src/main/java/radar/web/ProfileController.java
@@ -1,0 +1,30 @@
+package radar.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import radar.model.UserProfile;
+import radar.repository.JsonRepository;
+
+/** Reads and updates the user profile used to score offers. */
+@RestController
+public class ProfileController {
+
+  private final JsonRepository repository;
+
+  public ProfileController(JsonRepository repository) {
+    this.repository = repository;
+  }
+
+  @GetMapping("/api/profile")
+  public UserProfile get() {
+    return repository.readProfile();
+  }
+
+  @PutMapping("/api/profile")
+  public UserProfile update(@RequestBody UserProfile profile) {
+    repository.writeProfile(profile);
+    return repository.readProfile();
+  }
+}

--- a/src/main/java/radar/web/ScanController.java
+++ b/src/main/java/radar/web/ScanController.java
@@ -1,0 +1,33 @@
+package radar.web;
+
+import java.time.Duration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import radar.service.ScanService;
+
+/**
+ * Starts a scan and streams progress back over Server-Sent Events. The emitter is handed straight to
+ * {@link ScanService}; there is no polling endpoint.
+ */
+@RestController
+public class ScanController {
+
+  private static final long SCAN_TIMEOUT_MS = Duration.ofMinutes(30).toMillis();
+
+  private final ScanService scanService;
+
+  public ScanController(ScanService scanService) {
+    this.scanService = scanService;
+  }
+
+  @PostMapping("/api/scan")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public SseEmitter scan() {
+    SseEmitter emitter = new SseEmitter(SCAN_TIMEOUT_MS);
+    scanService.startScan(emitter);
+    return emitter;
+  }
+}

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -1,0 +1,136 @@
+package radar.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import radar.model.JobReport;
+import radar.model.RawJobOffer;
+import radar.model.SalaryRange;
+import radar.model.UserProfile;
+import radar.repository.JsonRepository;
+import radar.service.ReporterService;
+import radar.service.ScanService;
+
+/**
+ * Standalone MockMvc tests for the REST layer — no Spring context, so no dependency on the web test
+ * slice (which Spring Boot 4 splits into a separate module not on the classpath).
+ */
+class WebControllersTest {
+
+  private JsonRepository repository;
+  private ScanService scanService;
+  private ReporterService reporterService;
+  private MockMvc mvc;
+
+  private final UserProfile profile = new UserProfile(
+      List.of("Java", "Spring"), 3, "B2B", true, 15000, "PLN", "B2B", List.of("Kraków"), 6);
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(JsonRepository.class);
+    scanService = mock(ScanService.class);
+    reporterService = mock(ReporterService.class);
+    mvc = MockMvcBuilders.standaloneSetup(
+        new ScanController(scanService),
+        new JobController(repository),
+        new AnalyticsController(reporterService),
+        new ProfileController(repository)).build();
+  }
+
+  private JobReport report(String id, int score) {
+    RawJobOffer offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
+        "senior", null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin");
+    return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
+        List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));
+  }
+
+  @Test
+  void postScanStartsAsyncScanAndReturnsEmitter() throws Exception {
+    mvc.perform(post("/api/scan")).andExpect(request().asyncStarted());
+    verify(scanService).startScan(any());
+  }
+
+  @Test
+  void getJobsUsesLatestDateAndFiltersByMinMatchScore() throws Exception {
+    when(repository.listDates()).thenReturn(List.of("2026-07-03", "2026-07-04"));
+    when(repository.readProfile()).thenReturn(profile);
+    when(repository.loadJobs("2026-07-04")).thenReturn(List.of(report("a", 8), report("b", 4)));
+
+    mvc.perform(get("/api/jobs"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].matchScore").value(8));
+  }
+
+  @Test
+  void getJobsHonoursExplicitDateParam() throws Exception {
+    when(repository.readProfile()).thenReturn(profile);
+    when(repository.loadJobs("2026-07-01")).thenReturn(List.of(report("x", 9)));
+
+    mvc.perform(get("/api/jobs").param("date", "2026-07-01"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].rawJobOffer.id").value("x"));
+    verify(repository).loadJobs("2026-07-01");
+  }
+
+  @Test
+  void getJobsReturnsEmptyArrayWhenNoSnapshots() throws Exception {
+    when(repository.listDates()).thenReturn(List.of());
+
+    mvc.perform(get("/api/jobs"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  void getTrendsReturnsJson() throws Exception {
+    when(reporterService.computeTrends()).thenReturn(Map.of("Java", 5, "Spring", 2));
+
+    mvc.perform(get("/api/trends"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.Java").value(5));
+  }
+
+  @Test
+  void getProfileReturnsProfile() throws Exception {
+    when(repository.readProfile()).thenReturn(profile);
+
+    mvc.perform(get("/api/profile"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.minMatchScore").value(6))
+        .andExpect(jsonPath("$.currentSkills[0]").value("Java"));
+  }
+
+  @Test
+  void putProfilePersistsAndReturnsSaved() throws Exception {
+    when(repository.readProfile()).thenReturn(profile);
+    String body = """
+        {"currentSkills":["Java","Spring"],"experienceYears":3,"preferredType":"B2B",
+         "preferredRemote":true,"salaryMin":15000,"currency":"PLN","contractType":"B2B",
+         "locations":["Kraków"],"minMatchScore":6}
+        """;
+
+    mvc.perform(put("/api/profile").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.minMatchScore").value(6));
+
+    verify(repository).writeProfile(any(UserProfile.class));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `radar.web` controllers:
  - `POST /api/scan` → creates an `SseEmitter`, hands it to `ScanService.startScan`, returns it (202, `text/event-stream`); no polling endpoint
  - `GET /api/jobs` (optional `?date=`) → loads the latest (or given) snapshot, filtered by the profile's `minMatchScore`; `[]` when there are no snapshots
  - `GET /api/trends` → `ReporterService.computeTrends()`
  - `GET`/`PUT /api/profile` → read / persist the `UserProfile`
- Add `JacksonConfig` providing a **Jackson 2 `ObjectMapper` bean** — Spring Boot 4 auto-configures Jackson 3, so the `com.fasterxml.jackson.databind.ObjectMapper` the app injects was missing and the context failed to start. Caught by a real `bootRun`, not by unit tests.

## Test plan
- `./gradlew build` green; 7 standalone-MockMvc tests (Boot 4 has no `@WebMvcTest` slice on the classpath) cover scan async start, jobs latest-date + score filter + explicit date + empty, trends, profile GET/PUT
- **End-to-end:** `ANTHROPIC_API_KEY=dummy ./gradlew bootRun` starts in ~1.5s; `GET /api/profile` returns the default profile, `GET /api/jobs` → `[]`, `GET /api/trends` → `{}`, `PUT /api/profile` round-trips

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)