### PR TITLE
feat(VR-30): optional scan limit

### DIFF
--- a/src/main/java/radar/service/ScanService.java
+++ b/src/main/java/radar/service/ScanService.java
@@ -35,22 +35,26 @@ public class ScanService {
     this.repository = repository;
   }
 
-  /** Launches the scan asynchronously and returns immediately. */
-  public void startScan(SseEmitter emitter) {
-    CompletableFuture.runAsync(() -> runScan(emitter));
+  /**
+   * Launches the scan asynchronously and returns immediately.
+   *
+   * @param limit optional cap on how many new offers to enrich this run (null = no cap).
+   */
+  public void startScan(SseEmitter emitter, Integer limit) {
+    CompletableFuture.runAsync(() -> runScan(emitter, limit));
   }
 
   /**
    * The scan body. Package-private and synchronous so it can be unit-tested directly; {@link
    * #startScan} wraps it in a background task.
    */
-  void runScan(SseEmitter emitter) {
+  void runScan(SseEmitter emitter, Integer limit) {
     try {
       String date = LocalDate.now().toString();
       UserProfile profile = repository.readProfile();
 
       emit(emitter, new ScanProgress(ScanProgress.Type.SCANNING, "Scanning offers", null, null, null));
-      List<RawJobOffer> newOffers = scraperService.scrapeNew();
+      List<RawJobOffer> newOffers = capToLimit(scraperService.scrapeNew(), limit);
       emit(emitter, new ScanProgress(
           ScanProgress.Type.SCANNING, "Found new offers", 0, newOffers.size(), null));
 
@@ -81,6 +85,17 @@ public class ScanService {
       }
       emitter.completeWithError(e);
     }
+  }
+
+  /**
+   * Caps the offer list to at most {@code limit} entries. Because this runs before enrichment and
+   * {@code markAsSeen}, only the offers actually processed this run get marked seen.
+   */
+  private static List<RawJobOffer> capToLimit(List<RawJobOffer> offers, Integer limit) {
+    if (limit == null || limit < 0 || offers.size() <= limit) {
+      return offers;
+    }
+    return List.copyOf(offers.subList(0, limit));
   }
 
   /** Sends one progress event over SSE. Package-private/overridable so tests can observe the stream. */

--- a/src/main/java/radar/web/ScanController.java
+++ b/src/main/java/radar/web/ScanController.java
@@ -3,6 +3,7 @@ package radar.web;
 import java.time.Duration;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -23,11 +24,15 @@ public class ScanController {
     this.scanService = scanService;
   }
 
+  /**
+   * @param limit optional cap on how many new offers to enrich this run (useful for testing);
+   *              omit for a full scan.
+   */
   @PostMapping("/api/scan")
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public SseEmitter scan() {
+  public SseEmitter scan(@RequestParam(required = false) Integer limit) {
     SseEmitter emitter = new SseEmitter(SCAN_TIMEOUT_MS);
-    scanService.startScan(emitter);
+    scanService.startScan(emitter, limit);
     return emitter;
   }
 }

--- a/src/test/java/radar/service/ScanServiceTest.java
+++ b/src/test/java/radar/service/ScanServiceTest.java
@@ -83,7 +83,7 @@ class ScanServiceTest {
     });
     when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
 
-    scanService.runScan(emitter);
+    scanService.runScan(emitter, null);
 
     // event order: SCANNING, SCANNING, ENRICHING, ENRICHING, SAVING, DONE
     assertThat(emitted).extracting(ScanProgress::type).containsExactly(
@@ -116,7 +116,7 @@ class ScanServiceTest {
     when(enricher.enrichAll(anyList(), any(), any())).thenReturn(List.of(weak));
     when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
 
-    scanService.runScan(emitter);
+    scanService.runScan(emitter, null);
 
     ArgumentCaptor<List<JobReport>> jobs = ArgumentCaptor.forClass(List.class);
     verify(repository).saveJobs(anyString(), jobs.capture());
@@ -131,12 +131,37 @@ class ScanServiceTest {
     RuntimeException boom = new RuntimeException("scrape failed");
     when(scraper.scrapeNew()).thenThrow(boom);
 
-    scanService.runScan(emitter);
+    scanService.runScan(emitter, null);
 
     assertThat(emitted).extracting(ScanProgress::type)
         .contains(ScanProgress.Type.ERROR)
         .doesNotContain(ScanProgress.Type.DONE);
     verify(emitter).completeWithError(boom);
     verify(repository, org.mockito.Mockito.never()).saveJobs(anyString(), anyList());
+  }
+
+  @Test
+  void runScanCapsEnrichmentAndSeenIdsToLimit() {
+    RawJobOffer a = offer("a");
+    RawJobOffer b = offer("b");
+    RawJobOffer c = offer("c");
+    Analytics analytics = new Analytics("2026-07-04", 2, java.util.Map.of(), List.of(), null,
+        java.util.Map.of(), 100.0);
+
+    when(repository.readProfile()).thenReturn(profile);
+    when(scraper.scrapeNew()).thenReturn(List.of(a, b, c));
+    ArgumentCaptor<List<RawJobOffer>> enriched = ArgumentCaptor.forClass(List.class);
+    when(enricher.enrichAll(enriched.capture(), any(), any()))
+        .thenReturn(List.of(report(a, 8), report(b, 7)));
+    when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
+
+    scanService.runScan(emitter, 2);
+
+    // only the first 2 offers are enriched and marked seen; the third is left for a later run
+    assertThat(enriched.getValue()).containsExactly(a, b);
+    verify(scraper).markAsSeen(List.of("a", "b"));
+    ScanProgress done = emitted.get(emitted.size() - 1);
+    assertThat(done.type()).isEqualTo(ScanProgress.Type.DONE);
+    assertThat(done.total()).isEqualTo(2);
   }
 }

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -61,9 +61,15 @@ class WebControllersTest {
   }
 
   @Test
-  void postScanStartsAsyncScanAndReturnsEmitter() throws Exception {
+  void postScanStartsAsyncScanWithNoLimit() throws Exception {
     mvc.perform(post("/api/scan")).andExpect(request().asyncStarted());
-    verify(scanService).startScan(any());
+    verify(scanService).startScan(any(), org.mockito.ArgumentMatchers.isNull());
+  }
+
+  @Test
+  void postScanPassesLimitParam() throws Exception {
+    mvc.perform(post("/api/scan").param("limit", "20")).andExpect(request().asyncStarted());
+    verify(scanService).startScan(any(), org.mockito.ArgumentMatchers.eq(20));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `POST /api/scan?limit=N` caps how many new offers get enriched this run
- Cap is applied in `ScanService` right after `scrapeNew()`, so enrichment, analytics, save, and `markAsSeen` all operate on the capped set — the offers left out are NOT marked seen and remain for a later run
- Omitted/null → full scan (unchanged)

## Why
A first scan enriches all ~964 new offers (slow + costly). `?limit=20` makes a cheap, fast test run that actually completes and writes `jobs.json`.

## Test plan
- `./gradlew build` green; ScanServiceTest verifies limit=2 enriches only 2 offers, marks only those 2 seen, DONE total=2; WebControllersTest verifies the `limit` param is passed (and null when omitted)
- **Live:** `POST /api/scan?limit=2` emits `SCANNING total=2` (capped from 964)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)