### PR TITLE
feat(scraper): VR-31 store raw offers in a pooled file with retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ bin/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Runtime data (scraped offers, snapshots, seen ids) — not source
+data/

--- a/src/main/java/radar/model/ScanResult.java
+++ b/src/main/java/radar/model/ScanResult.java
@@ -1,0 +1,8 @@
+package radar.model;
+
+/**
+ * Outcome of a scrape: how many brand-new offers were added to {@code raw-offers.json} this run and
+ * how many offers the pool holds afterwards (post-retention).
+ */
+public record ScanResult(int added, int total) {
+}

--- a/src/main/java/radar/model/StoredRawOffer.java
+++ b/src/main/java/radar/model/StoredRawOffer.java
@@ -1,0 +1,14 @@
+package radar.model;
+
+/**
+ * A raw offer as persisted in {@code raw-offers.json}, together with the timestamp it was first
+ * scraped. The wrapper keeps {@link RawJobOffer} itself profile-independent: enrichment (matchScore
+ * and everything derived from a user profile) lives on {@code JobReport}, never here.
+ *
+ * @param offer       the scraped offer, unchanged
+ * @param firstSeenAt ISO-8601 instant of the first scan that saw this offer; used for retention.
+ *                    Stored as a String because the shared Jackson 2 {@code ObjectMapper} has no
+ *                    java.time module registered.
+ */
+public record StoredRawOffer(RawJobOffer offer, String firstSeenAt) {
+}

--- a/src/main/java/radar/repository/JsonRepository.java
+++ b/src/main/java/radar/repository/JsonRepository.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import radar.model.Analytics;
 import radar.model.JobReport;
+import radar.model.StoredRawOffer;
 import radar.model.UserProfile;
 
 /**
@@ -25,6 +26,7 @@ import radar.model.UserProfile;
  * <p>Layout:
  * <pre>
  *   {dataDir}/profile.json
+ *   {dataDir}/raw-offers.json    (pool of scraped offers, profile-independent)
  *   {dataDir}/seen-ids.json
  *   {dataDir}/{YYYY-MM-DD}/jobs.json
  *   {dataDir}/{YYYY-MM-DD}/analytics.json
@@ -37,6 +39,7 @@ import radar.model.UserProfile;
 public class JsonRepository {
 
   private static final String PROFILE_FILE = "profile.json";
+  private static final String RAW_OFFERS_FILE = "raw-offers.json";
   private static final String SEEN_IDS_FILE = "seen-ids.json";
   private static final String JOBS_FILE = "jobs.json";
   private static final String ANALYTICS_FILE = "analytics.json";
@@ -60,6 +63,30 @@ public class JsonRepository {
 
   public void writeProfile(UserProfile profile) {
     write(dataDir.resolve(PROFILE_FILE), profile);
+  }
+
+  // ---- raw offers ----
+
+  /** Returns the scraped-offer pool, or an empty list if it doesn't exist yet. */
+  public List<StoredRawOffer> readRawOffers() {
+    lock.readLock().lock();
+    try {
+      Path file = dataDir.resolve(RAW_OFFERS_FILE);
+      if (!Files.exists(file)) {
+        return new ArrayList<>();
+      }
+      return objectMapper.readValue(Files.readAllBytes(file),
+          new TypeReference<List<StoredRawOffer>>() {});
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + RAW_OFFERS_FILE, e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /** Overwrites the scraped-offer pool with {@code offers}. */
+  public void saveRawOffers(List<StoredRawOffer> offers) {
+    write(dataDir.resolve(RAW_OFFERS_FILE), offers);
   }
 
   // ---- seen ids ----

--- a/src/main/java/radar/service/ScraperService.java
+++ b/src/main/java/radar/service/ScraperService.java
@@ -1,39 +1,124 @@
 package radar.service;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import radar.connector.JustJoinConnector;
 import radar.model.RawJobOffer;
+import radar.model.ScanResult;
+import radar.model.StoredRawOffer;
 import radar.repository.JsonRepository;
 
 /**
- * Orchestrates scraping: fetches all offers from the connector and filters out the ones already
- * processed (tracked in {@code seen-ids.json}). Seen ids are only persisted after enrichment
- * succeeds, so {@link #markAsSeen(List)} is a separate step the caller invokes at the end of a scan.
+ * Orchestrates scraping. {@link #scan()} fetches every current offer from the connector, merges new
+ * ones into the {@code raw-offers.json} pool (deduplicating by id — the pool itself is the source of
+ * truth, no separate seen-ids list), and drops offers older than the configured retention window.
+ *
+ * <p>This step is profile-independent and never calls Claude — enrichment happens later, reading the
+ * pool this method fills.
  */
 @Service
 public class ScraperService {
 
+  private static final Logger log = LoggerFactory.getLogger(ScraperService.class);
+
   private final JustJoinConnector connector;
   private final JsonRepository repository;
+  private final int retentionDays;
 
-  public ScraperService(JustJoinConnector connector, JsonRepository repository) {
+  public ScraperService(JustJoinConnector connector, JsonRepository repository,
+      @Value("${radar.offers.retention-days:30}") int retentionDays) {
     this.connector = connector;
     this.repository = repository;
+    this.retentionDays = retentionDays;
+  }
+
+  /**
+   * Fetches current offers, merges brand-new ones into the pool (preserving each existing offer's
+   * {@code firstSeenAt}), prunes offers past the retention window, and persists the result.
+   */
+  public ScanResult scan() {
+    String now = Instant.now().toString();
+    List<RawJobOffer> fetched = connector.fetchAll();
+
+    // Key existing pool by id so we can preserve firstSeenAt and refresh the offer payload.
+    Map<String, StoredRawOffer> pool = new LinkedHashMap<>();
+    for (StoredRawOffer stored : repository.readRawOffers()) {
+      pool.put(stored.offer().id(), stored);
+    }
+
+    int added = 0;
+    for (RawJobOffer offer : fetched) {
+      StoredRawOffer existing = pool.get(offer.id());
+      if (existing == null) {
+        pool.put(offer.id(), new StoredRawOffer(offer, now));
+        added++;
+      } else {
+        // Same offer seen again: refresh its fields (salary/title may change) but keep firstSeenAt.
+        pool.put(offer.id(), new StoredRawOffer(offer, existing.firstSeenAt()));
+      }
+    }
+
+    Instant cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS);
+    List<StoredRawOffer> merged = pool.values().stream()
+        .filter(stored -> !isExpired(stored, cutoff))
+        .toList();
+
+    repository.saveRawOffers(merged);
+    log.info("Scan: fetched {}, added {}, pool size {} (retention {}d)",
+        fetched.size(), added, merged.size(), retentionDays);
+    return new ScanResult(added, merged.size());
+  }
+
+  /**
+   * An offer is expired when its reference date is before {@code cutoff}. The reference date is
+   * {@code publishedAt} when parseable, otherwise {@code firstSeenAt}. If neither parses, the offer
+   * is kept (we never drop an offer we can't date).
+   */
+  private static boolean isExpired(StoredRawOffer stored, Instant cutoff) {
+    Instant reference = parseInstant(stored.offer().publishedAt());
+    if (reference == null) {
+      reference = parseInstant(stored.firstSeenAt());
+    }
+    return reference != null && reference.isBefore(cutoff);
+  }
+
+  private static Instant parseInstant(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    try {
+      return Instant.parse(value);
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   /** Returns only offers whose id has not been seen before. Does not persist anything. */
+  @Deprecated
   public List<RawJobOffer> scrapeNew() {
     List<RawJobOffer> all = connector.fetchAll();
     Set<String> seen = new HashSet<>(repository.readSeenIds());
-    return all.stream()
-        .filter(offer -> !seen.contains(offer.id()))
-        .toList();
+    List<RawJobOffer> fresh = new ArrayList<>();
+    for (RawJobOffer offer : all) {
+      if (!seen.contains(offer.id())) {
+        fresh.add(offer);
+      }
+    }
+    return fresh;
   }
 
   /** Records the given offer ids as processed so they are skipped on the next scan. */
+  @Deprecated
   public void markAsSeen(List<String> ids) {
     repository.appendSeenIds(ids);
   }

--- a/src/main/java/radar/web/ScanController.java
+++ b/src/main/java/radar/web/ScanController.java
@@ -1,38 +1,27 @@
 package radar.web;
 
-import java.time.Duration;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import radar.service.ScanService;
+import radar.model.ScanResult;
+import radar.service.ScraperService;
 
 /**
- * Starts a scan and streams progress back over Server-Sent Events. The emitter is handed straight to
- * {@link ScanService}; there is no polling endpoint.
+ * Triggers a scrape. Scraping is fast (no enrichment, no Claude), so this endpoint runs
+ * synchronously and returns the {@link ScanResult} directly. Enrichment/evaluation is a separate
+ * endpoint.
  */
 @RestController
 public class ScanController {
 
-  private static final long SCAN_TIMEOUT_MS = Duration.ofMinutes(30).toMillis();
+  private final ScraperService scraperService;
 
-  private final ScanService scanService;
-
-  public ScanController(ScanService scanService) {
-    this.scanService = scanService;
+  public ScanController(ScraperService scraperService) {
+    this.scraperService = scraperService;
   }
 
-  /**
-   * @param limit optional cap on how many new offers to enrich this run (useful for testing);
-   *              omit for a full scan.
-   */
+  /** Fetches current offers into the raw-offers pool and returns how many were added / the total. */
   @PostMapping("/api/scan")
-  @ResponseStatus(HttpStatus.ACCEPTED)
-  public SseEmitter scan(@RequestParam(required = false) Integer limit) {
-    SseEmitter emitter = new SseEmitter(SCAN_TIMEOUT_MS);
-    scanService.startScan(emitter, limit);
-    return emitter;
+  public ScanResult scan() {
+    return scraperService.scan();
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 server.port=8080
 anthropic.api.key=${ANTHROPIC_API_KEY:}
+
+# How many days a scraped offer is kept in raw-offers.json before scan prunes it.
+radar.offers.retention-days=30

--- a/src/test/java/radar/service/ScraperServiceTest.java
+++ b/src/test/java/radar/service/ScraperServiceTest.java
@@ -4,19 +4,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import radar.connector.JustJoinConnector;
 import radar.model.RawJobOffer;
+import radar.model.ScanResult;
+import radar.model.StoredRawOffer;
 import radar.repository.JsonRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ScraperServiceTest {
+
+  private static final int RETENTION_DAYS = 30;
 
   @Mock
   JustJoinConnector connector;
@@ -24,14 +31,75 @@ class ScraperServiceTest {
   @Mock
   JsonRepository repository;
 
-  @InjectMocks
   ScraperService scraperService;
+
+  @BeforeEach
+  void setUp() {
+    scraperService = new ScraperService(connector, repository, RETENTION_DAYS);
+  }
 
   private RawJobOffer offer(String id) {
     return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
         null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
         "justjoin");
   }
+
+  private StoredRawOffer stored(String id, String firstSeenAt) {
+    return new StoredRawOffer(offer(id), firstSeenAt);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<StoredRawOffer> capturePersisted() {
+    ArgumentCaptor<List<StoredRawOffer>> captor = ArgumentCaptor.forClass(List.class);
+    verify(repository).saveRawOffers(captor.capture());
+    return captor.getValue();
+  }
+
+  // ---- scan ----
+
+  @Test
+  void scanAddsBrandNewOffersToEmptyPool() {
+    when(repository.readRawOffers()).thenReturn(List.of());
+    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
+
+    ScanResult result = scraperService.scan();
+
+    assertThat(result).isEqualTo(new ScanResult(2, 2));
+    List<StoredRawOffer> saved = capturePersisted();
+    assertThat(saved).extracting(s -> s.offer().id()).containsExactly("a", "b");
+    assertThat(saved).allSatisfy(s -> assertThat(s.firstSeenAt()).isNotBlank());
+  }
+
+  @Test
+  void scanPreservesFirstSeenForOffersAlreadyInPool() {
+    String seen = Instant.now().minus(5, ChronoUnit.DAYS).toString();
+    when(repository.readRawOffers()).thenReturn(List.of(stored("a", seen)));
+    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
+
+    ScanResult result = scraperService.scan();
+
+    assertThat(result).isEqualTo(new ScanResult(1, 2));
+    List<StoredRawOffer> saved = capturePersisted();
+    assertThat(saved).extracting(s -> s.offer().id()).containsExactly("a", "b");
+    assertThat(saved).filteredOn(s -> s.offer().id().equals("a"))
+        .allSatisfy(s -> assertThat(s.firstSeenAt()).isEqualTo(seen));
+  }
+
+  @Test
+  void scanPrunesOffersPastRetentionWindow() {
+    String old = Instant.now().minus(RETENTION_DAYS + 10L, ChronoUnit.DAYS).toString();
+    String recent = Instant.now().minus(2, ChronoUnit.DAYS).toString();
+    when(repository.readRawOffers())
+        .thenReturn(List.of(stored("old", old), stored("recent", recent)));
+    when(connector.fetchAll()).thenReturn(List.of());
+
+    ScanResult result = scraperService.scan();
+
+    assertThat(result).isEqualTo(new ScanResult(0, 1));
+    assertThat(capturePersisted()).extracting(s -> s.offer().id()).containsExactly("recent");
+  }
+
+  // ---- legacy scrapeNew (kept until evaluation is split out) ----
 
   @Test
   void scrapeNewFiltersOutSeenOffers() {
@@ -44,14 +112,6 @@ class ScraperServiceTest {
     assertThat(result).hasSize(7);
     assertThat(result).extracting(RawJobOffer::id)
         .containsExactly("id-1", "id-3", "id-4", "id-6", "id-7", "id-8", "id-10");
-  }
-
-  @Test
-  void scrapeNewReturnsAllWhenNothingSeen() {
-    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
-    when(repository.readSeenIds()).thenReturn(List.of());
-
-    assertThat(scraperService.scrapeNew()).extracting(RawJobOffer::id).containsExactly("a", "b");
   }
 
   @Test

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -22,10 +21,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import radar.model.JobReport;
 import radar.model.RawJobOffer;
 import radar.model.SalaryRange;
+import radar.model.ScanResult;
 import radar.model.UserProfile;
 import radar.repository.JsonRepository;
 import radar.service.ReporterService;
-import radar.service.ScanService;
+import radar.service.ScraperService;
 
 /**
  * Standalone MockMvc tests for the REST layer — no Spring context, so no dependency on the web test
@@ -34,7 +34,7 @@ import radar.service.ScanService;
 class WebControllersTest {
 
   private JsonRepository repository;
-  private ScanService scanService;
+  private ScraperService scraperService;
   private ReporterService reporterService;
   private MockMvc mvc;
 
@@ -44,10 +44,10 @@ class WebControllersTest {
   @BeforeEach
   void setUp() {
     repository = mock(JsonRepository.class);
-    scanService = mock(ScanService.class);
+    scraperService = mock(ScraperService.class);
     reporterService = mock(ReporterService.class);
     mvc = MockMvcBuilders.standaloneSetup(
-        new ScanController(scanService),
+        new ScanController(scraperService),
         new JobController(repository),
         new AnalyticsController(reporterService),
         new ProfileController(repository)).build();
@@ -61,15 +61,15 @@ class WebControllersTest {
   }
 
   @Test
-  void postScanStartsAsyncScanWithNoLimit() throws Exception {
-    mvc.perform(post("/api/scan")).andExpect(request().asyncStarted());
-    verify(scanService).startScan(any(), org.mockito.ArgumentMatchers.isNull());
-  }
+  void postScanRunsSynchronouslyAndReturnsResult() throws Exception {
+    when(scraperService.scan()).thenReturn(new ScanResult(5, 10));
 
-  @Test
-  void postScanPassesLimitParam() throws Exception {
-    mvc.perform(post("/api/scan").param("limit", "20")).andExpect(request().asyncStarted());
-    verify(scanService).startScan(any(), org.mockito.ArgumentMatchers.eq(20));
+    mvc.perform(post("/api/scan"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.added").value(5))
+        .andExpect(jsonPath("$.total").value(10));
+    verify(scraperService).scan();
   }
 
   @Test


### PR DESCRIPTION
## What

Splits scraping from enrichment. `POST /api/scan` now **only** scrapes and persists offers — no Claude call. Enrichment moves to a separate `/evaluate` endpoint in a follow-up chunk.

## Changes

- **New models** `StoredRawOffer` (`offer` + `firstSeenAt`) and `ScanResult` (`added`, `total`).
- **`JsonRepository`** — read/save `raw-offers.json` (the scraped-offer pool).
- **`ScraperService.scan()`** — fetch → merge new offers by id (preserves `firstSeenAt`, refreshes payload) → prune past retention → persist. Dedup is by the pool itself; **no separate `seen-ids` list**.
- **`ScanController`** — `/api/scan` is now **synchronous**, returns `ScanResult` (SSE removed).
- **Config** — `radar.offers.retention-days` (default 30) in `application.properties`.
- **`.gitignore`** — ignore `data/` (runtime artifacts, incl. `raw-offers.json`).

## Deliberately deferred (next chunk: `/evaluate`)

`ScanService`, `scrapeNew`, `markAsSeen`, and `seen-ids.json` are left **dormant and `@Deprecated`** so the build stays green. They become the `EvaluationService` / `POST /api/evaluate` flow next, along with `profileHash` on `JobReport`, `evaluation-state.json`, `GET /api/evaluation/status`, and the `@Scheduled` triggers.

⚠️ Consequence for this interim state: `jobs.json` / `analytics.json` are no longer produced by `/scan` until `/evaluate` lands.

## Tests

- `ScraperServiceTest` — new-offer add, `firstSeenAt` preservation, retention prune.
- `WebControllersTest` — `/scan` verified as synchronous, returning `{added,total}`.
- `./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)