### PR TITLE
feat(scraper): VR-32 incremental scan with newest-first paging

### DIFF
--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -54,19 +54,26 @@ public class JustJoinConnector {
         HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
   }
 
+  /** One page of results: the parsed offers plus the total page count reported by the API. */
+  public record OfferPage(List<RawJobOffer> offers, int totalPages) {
+  }
+
+  /** Upper bound on how many pages any caller will walk, as a runaway guard. */
+  public static final int MAX_PAGES = MAX_PAGES_SAFETY;
+
   /**
-   * Fetches every Java offer across all pages. Rate-limits between requests to stay polite.
+   * Fetches every Java offer across all pages, newest first. Rate-limits between requests to stay
+   * polite.
    */
   public List<RawJobOffer> fetchAll() {
     List<RawJobOffer> all = new ArrayList<>();
     int page = 1;
     int totalPages = 1;
     while (page <= totalPages && page <= MAX_PAGES_SAFETY) {
-      JsonNode root = fetchPage(page);
-      totalPages = root.path("meta").path("totalPages").asInt(1);
-      List<RawJobOffer> offers = parseOffers(root);
-      all.addAll(offers);
-      log.info("JustJoin page {}/{}: {} offers ({} total)", page, totalPages, offers.size(),
+      OfferPage p = fetchPage(page);
+      totalPages = p.totalPages();
+      all.addAll(p.offers());
+      log.info("JustJoin page {}/{}: {} offers ({} total)", page, totalPages, p.offers().size(),
           all.size());
       page++;
       if (page <= totalPages) {
@@ -76,9 +83,19 @@ public class JustJoinConnector {
     return all;
   }
 
-  private JsonNode fetchPage(int page) {
+  /**
+   * Fetches a single page of offers (newest first). Lets callers paginate lazily — e.g. an
+   * incremental scan that stops once it reaches already-known offers.
+   */
+  public OfferPage fetchPage(int page) {
+    JsonNode root = fetchPageJson(page);
+    int totalPages = root.path("meta").path("totalPages").asInt(1);
+    return new OfferPage(parseOffers(root), totalPages);
+  }
+
+  private JsonNode fetchPageJson(int page) {
     String url = API_BASE + "?categories%5B%5D=" + JAVA_CATEGORY_ID + "&page=" + page + "&perPage="
-        + PER_PAGE;
+        + PER_PAGE + "&sortBy=published&orderBy=DESC";
     HttpRequest request = HttpRequest.newBuilder(URI.create(url))
         .header("User-Agent", USER_AGENT)
         .header("Accept", "application/json")

--- a/src/main/java/radar/service/ScraperService.java
+++ b/src/main/java/radar/service/ScraperService.java
@@ -43,28 +43,59 @@ public class ScraperService {
   }
 
   /**
-   * Fetches current offers, merges brand-new ones into the pool (preserving each existing offer's
-   * {@code firstSeenAt}), prunes offers past the retention window, and persists the result.
+   * Walks the connector newest-first, merging brand-new offers into the pool (preserving each
+   * existing offer's {@code firstSeenAt}), prunes offers past the retention window, and persists.
+   *
+   * @param fullFetch when {@code false} (default), stops paginating as soon as a whole page holds no
+   *                  offer that wasn't already in the pool — cheap incremental scans. When
+   *                  {@code true}, walks every page to refresh the entire pool.
+   * @param limit     optional cap on how many offers to process this run (newest first); {@code null}
+   *                  = no cap.
    */
-  public ScanResult scan() {
+  public ScanResult scan(boolean fullFetch, Integer limit) {
     String now = Instant.now().toString();
-    List<RawJobOffer> fetched = connector.fetchAll();
 
-    // Key existing pool by id so we can preserve firstSeenAt and refresh the offer payload.
+    // Existing pool, keyed by id. knownIds is a snapshot: an offer is "new" only if absent here.
     Map<String, StoredRawOffer> pool = new LinkedHashMap<>();
     for (StoredRawOffer stored : repository.readRawOffers()) {
       pool.put(stored.offer().id(), stored);
     }
+    Set<String> knownIds = new HashSet<>(pool.keySet());
 
     int added = 0;
-    for (RawJobOffer offer : fetched) {
-      StoredRawOffer existing = pool.get(offer.id());
-      if (existing == null) {
-        pool.put(offer.id(), new StoredRawOffer(offer, now));
-        added++;
-      } else {
-        // Same offer seen again: refresh its fields (salary/title may change) but keep firstSeenAt.
-        pool.put(offer.id(), new StoredRawOffer(offer, existing.firstSeenAt()));
+    int processed = 0;
+    int page = 1;
+    int totalPages = 1;
+    boolean limitReached = false;
+
+    while (page <= totalPages && page <= JustJoinConnector.MAX_PAGES && !limitReached) {
+      JustJoinConnector.OfferPage p = connector.fetchPage(page);
+      totalPages = p.totalPages();
+
+      int newOnPage = 0;
+      for (RawJobOffer offer : p.offers()) {
+        if (limit != null && processed >= limit) {
+          limitReached = true;
+          break;
+        }
+        StoredRawOffer existing = pool.get(offer.id());
+        String firstSeen = existing == null ? now : existing.firstSeenAt();
+        pool.put(offer.id(), new StoredRawOffer(offer, firstSeen));
+        if (!knownIds.contains(offer.id())) {
+          added++;
+          newOnPage++;
+        }
+        processed++;
+      }
+      log.info("Scan page {}/{}: {} offers, {} new", page, totalPages, p.offers().size(), newOnPage);
+
+      // Incremental stop: once a full page brought nothing new, older pages hold only known offers.
+      if (!fullFetch && !limitReached && newOnPage == 0) {
+        break;
+      }
+      page++;
+      if (page <= totalPages && !limitReached) {
+        sleepPolitely();
       }
     }
 
@@ -74,9 +105,17 @@ public class ScraperService {
         .toList();
 
     repository.saveRawOffers(merged);
-    log.info("Scan: fetched {}, added {}, pool size {} (retention {}d)",
-        fetched.size(), added, merged.size(), retentionDays);
+    log.info("Scan done: added {}, pool size {} (fullFetch={}, limit={}, retention {}d)",
+        added, merged.size(), fullFetch, limit, retentionDays);
     return new ScanResult(added, merged.size());
+  }
+
+  private static void sleepPolitely() {
+    try {
+      Thread.sleep(500 + java.util.concurrent.ThreadLocalRandom.current().nextInt(500));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   /**

--- a/src/main/java/radar/web/ScanController.java
+++ b/src/main/java/radar/web/ScanController.java
@@ -1,6 +1,7 @@
 package radar.web;
 
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import radar.model.ScanResult;
 import radar.service.ScraperService;
@@ -19,9 +20,17 @@ public class ScanController {
     this.scraperService = scraperService;
   }
 
-  /** Fetches current offers into the raw-offers pool and returns how many were added / the total. */
+  /**
+   * Fetches current offers into the raw-offers pool and returns how many were added / the total.
+   *
+   * @param fullFetch walk every page to refresh the whole pool; default {@code false} stops early
+   *                  once a page brings nothing new (cheap incremental scan)
+   * @param limit     cap on how many offers to process this run (newest first); omit for no cap
+   */
   @PostMapping("/api/scan")
-  public ScanResult scan() {
-    return scraperService.scan();
+  public ScanResult scan(
+      @RequestParam(defaultValue = "false") boolean fullFetch,
+      @RequestParam(required = false) Integer limit) {
+    return scraperService.scan(fullFetch, limit);
   }
 }

--- a/src/test/java/radar/service/ScraperServiceTest.java
+++ b/src/test/java/radar/service/ScraperServiceTest.java
@@ -1,6 +1,7 @@
 package radar.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import radar.connector.JustJoinConnector;
+import radar.connector.JustJoinConnector.OfferPage;
 import radar.model.RawJobOffer;
 import radar.model.ScanResult;
 import radar.model.StoredRawOffer;
@@ -48,6 +50,11 @@ class ScraperServiceTest {
     return new StoredRawOffer(offer(id), firstSeenAt);
   }
 
+  private OfferPage page(int totalPages, String... ids) {
+    return new OfferPage(IntStream.range(0, ids.length).mapToObj(i -> offer(ids[i])).toList(),
+        totalPages);
+  }
+
   @SuppressWarnings("unchecked")
   private List<StoredRawOffer> capturePersisted() {
     ArgumentCaptor<List<StoredRawOffer>> captor = ArgumentCaptor.forClass(List.class);
@@ -55,34 +62,66 @@ class ScraperServiceTest {
     return captor.getValue();
   }
 
-  // ---- scan ----
-
   @Test
   void scanAddsBrandNewOffersToEmptyPool() {
     when(repository.readRawOffers()).thenReturn(List.of());
-    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
+    when(connector.fetchPage(1)).thenReturn(page(1, "a", "b"));
 
-    ScanResult result = scraperService.scan();
+    ScanResult result = scraperService.scan(false, null);
 
     assertThat(result).isEqualTo(new ScanResult(2, 2));
-    List<StoredRawOffer> saved = capturePersisted();
-    assertThat(saved).extracting(s -> s.offer().id()).containsExactly("a", "b");
-    assertThat(saved).allSatisfy(s -> assertThat(s.firstSeenAt()).isNotBlank());
+    assertThat(capturePersisted()).extracting(s -> s.offer().id()).containsExactly("a", "b");
   }
 
   @Test
   void scanPreservesFirstSeenForOffersAlreadyInPool() {
     String seen = Instant.now().minus(5, ChronoUnit.DAYS).toString();
     when(repository.readRawOffers()).thenReturn(List.of(stored("a", seen)));
-    when(connector.fetchAll()).thenReturn(List.of(offer("a"), offer("b")));
+    when(connector.fetchPage(1)).thenReturn(page(1, "a", "b"));
 
-    ScanResult result = scraperService.scan();
+    ScanResult result = scraperService.scan(true, null);
 
     assertThat(result).isEqualTo(new ScanResult(1, 2));
-    List<StoredRawOffer> saved = capturePersisted();
-    assertThat(saved).extracting(s -> s.offer().id()).containsExactly("a", "b");
-    assertThat(saved).filteredOn(s -> s.offer().id().equals("a"))
+    assertThat(capturePersisted()).filteredOn(s -> s.offer().id().equals("a"))
         .allSatisfy(s -> assertThat(s.firstSeenAt()).isEqualTo(seen));
+  }
+
+  @Test
+  void scanStopsEarlyOnceAPageBringsNothingNew() {
+    when(repository.readRawOffers()).thenReturn(List.of(stored("x", Instant.now().toString())));
+    when(connector.fetchPage(1)).thenReturn(page(3, "n1"));   // n1 is new -> keep going
+    when(connector.fetchPage(2)).thenReturn(page(3, "x"));    // all known -> stop
+
+    ScanResult result = scraperService.scan(false, null);
+
+    assertThat(result).isEqualTo(new ScanResult(1, 2));
+    verify(connector).fetchPage(1);
+    verify(connector).fetchPage(2);
+    verify(connector, never()).fetchPage(3);
+  }
+
+  @Test
+  void fullFetchKeepsWalkingPastAnAllKnownPage() {
+    when(repository.readRawOffers()).thenReturn(List.of(stored("x", Instant.now().toString())));
+    when(connector.fetchPage(1)).thenReturn(page(2, "x"));    // all known, but fullFetch -> continue
+    when(connector.fetchPage(2)).thenReturn(page(2, "n1"));
+
+    ScanResult result = scraperService.scan(true, null);
+
+    assertThat(result).isEqualTo(new ScanResult(1, 2));
+    verify(connector).fetchPage(2);
+  }
+
+  @Test
+  void limitCapsHowManyOffersAreProcessed() {
+    when(repository.readRawOffers()).thenReturn(List.of());
+    when(connector.fetchPage(1)).thenReturn(page(1, "a", "b", "c"));
+
+    ScanResult result = scraperService.scan(false, 2);
+
+    assertThat(result).isEqualTo(new ScanResult(2, 2));
+    assertThat(capturePersisted()).extracting(s -> s.offer().id()).containsExactly("a", "b");
+    verify(connector, never()).fetchPage(2);
   }
 
   @Test
@@ -91,9 +130,9 @@ class ScraperServiceTest {
     String recent = Instant.now().minus(2, ChronoUnit.DAYS).toString();
     when(repository.readRawOffers())
         .thenReturn(List.of(stored("old", old), stored("recent", recent)));
-    when(connector.fetchAll()).thenReturn(List.of());
+    when(connector.fetchPage(1)).thenReturn(new OfferPage(List.of(), 1));
 
-    ScanResult result = scraperService.scan();
+    ScanResult result = scraperService.scan(true, null);
 
     assertThat(result).isEqualTo(new ScanResult(0, 1));
     assertThat(capturePersisted()).extracting(s -> s.offer().id()).containsExactly("recent");

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -61,15 +61,25 @@ class WebControllersTest {
   }
 
   @Test
-  void postScanRunsSynchronouslyAndReturnsResult() throws Exception {
-    when(scraperService.scan()).thenReturn(new ScanResult(5, 10));
+  void postScanRunsSynchronouslyWithIncrementalDefaults() throws Exception {
+    when(scraperService.scan(false, null)).thenReturn(new ScanResult(5, 10));
 
     mvc.perform(post("/api/scan"))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.added").value(5))
         .andExpect(jsonPath("$.total").value(10));
-    verify(scraperService).scan();
+    verify(scraperService).scan(false, null);
+  }
+
+  @Test
+  void postScanPassesFullFetchAndLimitParams() throws Exception {
+    when(scraperService.scan(true, 20)).thenReturn(new ScanResult(20, 964));
+
+    mvc.perform(post("/api/scan").param("fullFetch", "true").param("limit", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.added").value(20));
+    verify(scraperService).scan(true, 20);
   }
 
   @Test


### PR DESCRIPTION
## What

Makes `POST /api/scan` incremental. Offers are fetched **newest-first** (`sortBy=published&orderBy=DESC`) and pagination **stops once a page brings nothing new** — so a repeat scan touches one page instead of re-downloading the whole list.

## Changes

- **`JustJoinConnector`** — `sortBy=published&orderBy=DESC` in the query; new `fetchPage(page)` → `OfferPage(offers, totalPages)` for lazy pagination; `fetchAll()` reuses it.
- **`ScraperService.scan(fullFetch, limit)`** — walks newest-first, merges new offers (preserving `firstSeenAt`), **early-stops** when a page has zero new ids, prunes past retention.
- **Flags** — `fullFetch=true` walks every page (refresh the whole pool); `limit=N` caps how many offers are processed (newest first).
- **`ScanController`** — `POST /api/scan?fullFetch=&limit=`.

## Tests

`ScraperServiceTest`: early-stop, `fullFetch` override, `limit` cap, retention prune (+ existing add/preserve). `WebControllersTest`: default incremental call + param pass-through. `./gradlew test` green.

## Verified live

- First (full) pool already had 964 offers. Repeat `POST /api/scan` → `{"added":0,"total":964}`, log `Scan page 1/10: 100 offers, 0 new` → stopped at page 1 (~1.2s vs full walk).
- `?limit=3` → processes newest 3 only.

## Next

Stage 2 — fetch per-offer page details (JSON-LD JobPosting → `domain` + full `description`) into the raw pool, still no AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)