### PR TITLE
refactor(style): VR-33 use var for local variables project-wide

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,25 @@
+# Code Style
+
+## Local variables — always `var`
+
+Java 25. Use `var` for **every local variable** where the compiler allows it —
+never write the explicit type when `var` works.
+
+```java
+// good
+var pool = new LinkedHashMap<String, StoredRawOffer>();
+var offers = connector.fetchPage(page);
+for (var offer : offers) { ... }
+
+// avoid
+LinkedHashMap<String, StoredRawOffer> pool = new LinkedHashMap<>();
+List<RawJobOffer> offers = ...;
+```
+
+- Plain `var`, **not** `final var`.
+- Applies to locals with an initializer and to enhanced-for loop variables.
+- `var` is **not** legal for fields, method parameters, method return types,
+  record components, or locals without an initializer — keep explicit types there.
+- Keep an explicit type only when `var` genuinely won't compile (e.g. the
+  initializer is `null`, an array initializer `{...}`, or a lambda/method-ref
+  that needs a target type).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,10 @@ radar.web         — REST controllers
 - Do NOT implement Phase 2 features (UI, GoWork, NoFluffJobs, Pracuj, LinkedIn)
 - Do NOT use database — JSON files only
 - Do NOT send HTML to Claude API
+
+---
+
+## Code Style
+
+- Use `var` for every local variable where the compiler allows it (Java 25).
+  See `.claude/rules/code-style.md`.

--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -66,11 +66,11 @@ public class JustJoinConnector {
    * polite.
    */
   public List<RawJobOffer> fetchAll() {
-    List<RawJobOffer> all = new ArrayList<>();
-    int page = 1;
-    int totalPages = 1;
+    var all = new ArrayList<RawJobOffer>();
+    var page = 1;
+    var totalPages = 1;
     while (page <= totalPages && page <= MAX_PAGES_SAFETY) {
-      OfferPage p = fetchPage(page);
+      var p = fetchPage(page);
       totalPages = p.totalPages();
       all.addAll(p.offers());
       log.info("JustJoin page {}/{}: {} offers ({} total)", page, totalPages, p.offers().size(),
@@ -88,15 +88,15 @@ public class JustJoinConnector {
    * incremental scan that stops once it reaches already-known offers.
    */
   public OfferPage fetchPage(int page) {
-    JsonNode root = fetchPageJson(page);
-    int totalPages = root.path("meta").path("totalPages").asInt(1);
+    var root = fetchPageJson(page);
+    var totalPages = root.path("meta").path("totalPages").asInt(1);
     return new OfferPage(parseOffers(root), totalPages);
   }
 
   private JsonNode fetchPageJson(int page) {
-    String url = API_BASE + "?categories%5B%5D=" + JAVA_CATEGORY_ID + "&page=" + page + "&perPage="
+    var url = API_BASE + "?categories%5B%5D=" + JAVA_CATEGORY_ID + "&page=" + page + "&perPage="
         + PER_PAGE + "&sortBy=published&orderBy=DESC";
-    HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+    var request = HttpRequest.newBuilder(URI.create(url))
         .header("User-Agent", USER_AGENT)
         .header("Accept", "application/json")
         .header("Referer", "https://justjoin.it/")
@@ -105,7 +105,7 @@ public class JustJoinConnector {
         .GET()
         .build();
     try {
-      HttpResponse<String> response =
+      var response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() != 200) {
         throw new IllegalStateException(
@@ -125,16 +125,16 @@ public class JustJoinConnector {
    * fixture, without touching the network.
    */
   List<RawJobOffer> parseOffers(JsonNode root) {
-    List<RawJobOffer> offers = new ArrayList<>();
-    for (JsonNode node : root.path("data")) {
+    var offers = new ArrayList<RawJobOffer>();
+    for (var node : root.path("data")) {
       offers.add(toRawJobOffer(node));
     }
     return offers;
   }
 
   private RawJobOffer toRawJobOffer(JsonNode n) {
-    String slug = textOrNull(n, "slug");
-    JsonNode salary = n.path("employmentTypes").path(0);
+    var slug = textOrNull(n, "slug");
+    var salary = n.path("employmentTypes").path(0);
     return new RawJobOffer(
         textOrNull(n, "guid"),
         textOrNull(n, "title"),
@@ -155,9 +155,9 @@ public class JustJoinConnector {
   }
 
   private static List<String> readSkills(JsonNode skillsNode) {
-    List<String> skills = new ArrayList<>();
+    var skills = new ArrayList<String>();
     if (skillsNode.isArray()) {
-      for (JsonNode s : skillsNode) {
+      for (var s : skillsNode) {
         // requiredSkills may be an array of strings or of objects with a "name" field
         if (s.isTextual()) {
           skills.add(s.asText());
@@ -170,17 +170,17 @@ public class JustJoinConnector {
   }
 
   private static String textOrNull(JsonNode node, String field) {
-    JsonNode v = node.get(field);
+    var v = node.get(field);
     return v == null || v.isNull() ? null : v.asText();
   }
 
   private static String upperOrNull(JsonNode node, String field) {
-    String v = textOrNull(node, field);
+    var v = textOrNull(node, field);
     return v == null ? null : v.toUpperCase();
   }
 
   private static Integer intOrNull(JsonNode node, String field) {
-    JsonNode v = node.get(field);
+    var v = node.get(field);
     return v == null || v.isNull() || !v.isNumber() ? null : v.asInt();
   }
 

--- a/src/main/java/radar/repository/JsonRepository.java
+++ b/src/main/java/radar/repository/JsonRepository.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import radar.model.Analytics;
@@ -71,7 +70,7 @@ public class JsonRepository {
   public List<StoredRawOffer> readRawOffers() {
     lock.readLock().lock();
     try {
-      Path file = dataDir.resolve(RAW_OFFERS_FILE);
+      var file = dataDir.resolve(RAW_OFFERS_FILE);
       if (!Files.exists(file)) {
         return new ArrayList<>();
       }
@@ -95,7 +94,7 @@ public class JsonRepository {
   public List<String> readSeenIds() {
     lock.readLock().lock();
     try {
-      Path file = dataDir.resolve(SEEN_IDS_FILE);
+      var file = dataDir.resolve(SEEN_IDS_FILE);
       if (!Files.exists(file)) {
         return new ArrayList<>();
       }
@@ -111,7 +110,7 @@ public class JsonRepository {
   public void appendSeenIds(List<String> newIds) {
     lock.writeLock().lock();
     try {
-      LinkedHashSet<String> merged = new LinkedHashSet<>(readSeenIdsUnlocked());
+      var merged = new LinkedHashSet<>(readSeenIdsUnlocked());
       merged.addAll(newIds);
       writeUnlocked(dataDir.resolve(SEEN_IDS_FILE), new ArrayList<>(merged));
     } finally {
@@ -129,7 +128,7 @@ public class JsonRepository {
   public List<JobReport> loadJobs(String date) {
     lock.readLock().lock();
     try {
-      Path file = dateDir(date).resolve(JOBS_FILE);
+      var file = dateDir(date).resolve(JOBS_FILE);
       if (!Files.exists(file)) {
         return new ArrayList<>();
       }
@@ -161,7 +160,7 @@ public class JsonRepository {
       if (!Files.isDirectory(dataDir)) {
         return new ArrayList<>();
       }
-      try (Stream<Path> entries = Files.list(dataDir)) {
+      try (var entries = Files.list(dataDir)) {
         return entries
             .filter(Files::isDirectory)
             .map(p -> p.getFileName().toString())
@@ -179,7 +178,7 @@ public class JsonRepository {
   // ---- internals ----
 
   private List<String> readSeenIdsUnlocked() throws RuntimeException {
-    Path file = dataDir.resolve(SEEN_IDS_FILE);
+    var file = dataDir.resolve(SEEN_IDS_FILE);
     if (!Files.exists(file)) {
       return new ArrayList<>();
     }
@@ -220,7 +219,7 @@ public class JsonRepository {
   private void writeUnlocked(Path file, Object value) {
     try {
       ensureDir(file.getParent());
-      byte[] bytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(value);
+      var bytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(value);
       Files.write(file, bytes);
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write " + file, e);

--- a/src/main/java/radar/service/EnricherService.java
+++ b/src/main/java/radar/service/EnricherService.java
@@ -2,8 +2,6 @@ package radar.service;
 
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.models.messages.MessageCreateParams;
-import com.anthropic.models.messages.StructuredMessage;
-import com.anthropic.models.messages.StructuredMessageCreateParams;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
@@ -41,7 +39,7 @@ public class EnricherService {
 
   /** Enriches a single offer against the user's profile. */
   public JobReport enrich(RawJobOffer offer, UserProfile profile) {
-    EnrichmentResult result = requestEnrichment(buildPrompt(offer, profile));
+    var result = requestEnrichment(buildPrompt(offer, profile));
     return toReport(result, offer);
   }
 
@@ -51,10 +49,10 @@ public class EnricherService {
    */
   public List<JobReport> enrichAll(List<RawJobOffer> offers, UserProfile profile,
       Consumer<ScanProgress> progressCallback) {
-    List<JobReport> reports = new ArrayList<>();
-    int total = offers.size();
-    for (int i = 0; i < total; i++) {
-      RawJobOffer offer = offers.get(i);
+    var reports = new ArrayList<JobReport>();
+    var total = offers.size();
+    for (var i = 0; i < total; i++) {
+      var offer = offers.get(i);
       reports.add(enrich(offer, profile));
       progressCallback.accept(new ScanProgress(
           ScanProgress.Type.ENRICHING, "Enriched " + offer.title(), i + 1, total, null));
@@ -67,13 +65,13 @@ public class EnricherService {
    * overridable so tests can exercise the surrounding logic without hitting the network.
    */
   EnrichmentResult requestEnrichment(String prompt) {
-    StructuredMessageCreateParams<EnrichmentResult> params = MessageCreateParams.builder()
+    var params = MessageCreateParams.builder()
         .model(MODEL)
         .maxTokens(MAX_TOKENS)
         .outputConfig(EnrichmentResult.class)
         .addUserMessage(prompt)
         .build();
-    StructuredMessage<EnrichmentResult> message = client.messages().create(params);
+    var message = client.messages().create(params);
     return message.content().stream()
         .flatMap(block -> block.text().stream())
         .map(text -> text.text())
@@ -83,7 +81,7 @@ public class EnricherService {
 
   /** Builds the plain-text prompt. Package-private for testing (asserts no HTML leaks in). */
   String buildPrompt(RawJobOffer offer, UserProfile profile) {
-    StringBuilder sb = new StringBuilder();
+    var sb = new StringBuilder();
     sb.append("You are a career advisor. Analyse the following job offer for this candidate ")
         .append("and score how well it matches their profile on a scale of 1 to 10.\n\n");
     sb.append("=== CANDIDATE PROFILE (JSON) ===\n").append(writeJson(profile)).append("\n\n");
@@ -108,7 +106,7 @@ public class EnricherService {
 
   /** Maps the model's result onto a JobReport, clamping the score to the valid 1-10 range. */
   JobReport toReport(EnrichmentResult r, RawJobOffer offer) {
-    int score = Math.max(MIN_SCORE, Math.min(MAX_SCORE, r.matchScore()));
+    var score = Math.max(MIN_SCORE, Math.min(MAX_SCORE, r.matchScore()));
     return new JobReport(offer, r.keySkills(), r.niceToHave(), r.projectType(), r.realSeniority(),
         r.redFlags(), r.greenFlags(), r.interviewFocus(), score, r.salary());
   }

--- a/src/main/java/radar/service/ReporterService.java
+++ b/src/main/java/radar/service/ReporterService.java
@@ -29,7 +29,7 @@ public class ReporterService {
 
   /** Builds the analytics snapshot for a date from every enriched report (no score filtering). */
   public Analytics buildAnalytics(String date, List<JobReport> allReports) {
-    int total = allReports.size();
+    var total = allReports.size();
     return new Analytics(
         date,
         total,
@@ -45,8 +45,8 @@ public class ReporterService {
    * total frequency descending.
    */
   public Map<String, Integer> computeTrends() {
-    Map<String, Integer> merged = new HashMap<>();
-    for (String date : repository.listDates()) {
+    var merged = new HashMap<String, Integer>();
+    for (var date : repository.listDates()) {
       Analytics analytics;
       try {
         analytics = repository.loadAnalytics(date);
@@ -61,10 +61,10 @@ public class ReporterService {
   }
 
   private Map<String, Integer> skillFrequency(List<JobReport> reports) {
-    Map<String, Integer> counts = new HashMap<>();
-    for (JobReport report : reports) {
+    var counts = new HashMap<String, Integer>();
+    for (var report : reports) {
       if (report.keySkills() != null) {
-        for (String skill : report.keySkills()) {
+        for (var skill : report.keySkills()) {
           counts.merge(skill, 1, Integer::sum);
         }
       }
@@ -73,9 +73,9 @@ public class ReporterService {
   }
 
   private List<String> topCompanies(List<JobReport> reports) {
-    Map<String, Integer> counts = new HashMap<>();
-    for (JobReport report : reports) {
-      String company = report.rawJobOffer() == null ? null : report.rawJobOffer().companyName();
+    var counts = new HashMap<String, Integer>();
+    for (var report : reports) {
+      var company = report.rawJobOffer() == null ? null : report.rawJobOffer().companyName();
       if (company != null && !company.isBlank()) {
         counts.merge(company, 1, Integer::sum);
       }
@@ -88,7 +88,7 @@ public class ReporterService {
   }
 
   private SalaryRange salaryDistribution(List<JobReport> reports) {
-    List<Integer> mins = reports.stream()
+    var mins = reports.stream()
         .map(JobReport::salary)
         .filter(s -> s != null && s.min() != null)
         .map(SalaryRange::min)
@@ -97,7 +97,7 @@ public class ReporterService {
     if (mins.isEmpty()) {
       return new SalaryRange(null, null, null);
     }
-    String currency = reports.stream()
+    var currency = reports.stream()
         .map(JobReport::salary)
         .filter(s -> s != null && s.currency() != null)
         .map(SalaryRange::currency)
@@ -110,11 +110,11 @@ public class ReporterService {
     if (total == 0) {
       return new LinkedHashMap<>();
     }
-    Map<String, Long> counts = reports.stream()
+    var counts = reports.stream()
         .map(JobReport::projectType)
         .filter(t -> t != null && !t.isBlank())
         .collect(Collectors.groupingBy(t -> t, Collectors.counting()));
-    LinkedHashMap<String, Double> breakdown = new LinkedHashMap<>();
+    var breakdown = new LinkedHashMap<String, Double>();
     counts.entrySet().stream()
         .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
         .forEach(e -> breakdown.put(e.getKey(), e.getValue() * 100.0 / total));
@@ -125,7 +125,7 @@ public class ReporterService {
     if (total == 0) {
       return 0.0;
     }
-    long remote = reports.stream()
+    var remote = reports.stream()
         .map(JobReport::rawJobOffer)
         .filter(o -> o != null && Boolean.TRUE.equals(o.remote()))
         .count();
@@ -133,7 +133,7 @@ public class ReporterService {
   }
 
   private static Map<String, Integer> sortByValueDesc(Map<String, Integer> counts) {
-    LinkedHashMap<String, Integer> sorted = new LinkedHashMap<>();
+    var sorted = new LinkedHashMap<String, Integer>();
     counts.entrySet().stream()
         .sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(Map.Entry::getValue).reversed()
             .thenComparing(Map.Entry::getKey))

--- a/src/main/java/radar/service/ScanService.java
+++ b/src/main/java/radar/service/ScanService.java
@@ -7,11 +7,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import radar.model.Analytics;
-import radar.model.JobReport;
 import radar.model.RawJobOffer;
 import radar.model.ScanProgress;
-import radar.model.UserProfile;
 import radar.repository.JsonRepository;
 
 /**
@@ -50,20 +47,20 @@ public class ScanService {
    */
   void runScan(SseEmitter emitter, Integer limit) {
     try {
-      String date = LocalDate.now().toString();
-      UserProfile profile = repository.readProfile();
+      var date = LocalDate.now().toString();
+      var profile = repository.readProfile();
 
       emit(emitter, new ScanProgress(ScanProgress.Type.SCANNING, "Scanning offers", null, null, null));
-      List<RawJobOffer> newOffers = capToLimit(scraperService.scrapeNew(), limit);
+      var newOffers = capToLimit(scraperService.scrapeNew(), limit);
       emit(emitter, new ScanProgress(
           ScanProgress.Type.SCANNING, "Found new offers", 0, newOffers.size(), null));
 
-      List<JobReport> allReports =
+      var allReports =
           enricherService.enrichAll(newOffers, profile, progress -> emit(emitter, progress));
 
-      Analytics analytics = reporterService.buildAnalytics(date, allReports);
-      int minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
-      List<JobReport> filtered = allReports.stream()
+      var analytics = reporterService.buildAnalytics(date, allReports);
+      var minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
+      var filtered = allReports.stream()
           .filter(report -> report.matchScore() >= minScore)
           .toList();
 

--- a/src/main/java/radar/service/ScraperService.java
+++ b/src/main/java/radar/service/ScraperService.java
@@ -6,8 +6,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,9 +18,10 @@ import radar.model.StoredRawOffer;
 import radar.repository.JsonRepository;
 
 /**
- * Orchestrates scraping. {@link #scan()} fetches every current offer from the connector, merges new
- * ones into the {@code raw-offers.json} pool (deduplicating by id — the pool itself is the source of
- * truth, no separate seen-ids list), and drops offers older than the configured retention window.
+ * Orchestrates scraping. {@link #scan(boolean, Integer)} fetches offers from the connector
+ * newest-first, merges new ones into the {@code raw-offers.json} pool (deduplicating by id — the pool
+ * itself is the source of truth, no separate seen-ids list), and drops offers older than the
+ * configured retention window.
  *
  * <p>This step is profile-independent and never calls Claude — enrichment happens later, reading the
  * pool this method fills.
@@ -53,33 +53,33 @@ public class ScraperService {
    *                  = no cap.
    */
   public ScanResult scan(boolean fullFetch, Integer limit) {
-    String now = Instant.now().toString();
+    var now = Instant.now().toString();
 
     // Existing pool, keyed by id. knownIds is a snapshot: an offer is "new" only if absent here.
-    Map<String, StoredRawOffer> pool = new LinkedHashMap<>();
-    for (StoredRawOffer stored : repository.readRawOffers()) {
+    var pool = new LinkedHashMap<String, StoredRawOffer>();
+    for (var stored : repository.readRawOffers()) {
       pool.put(stored.offer().id(), stored);
     }
-    Set<String> knownIds = new HashSet<>(pool.keySet());
+    var knownIds = new HashSet<>(pool.keySet());
 
-    int added = 0;
-    int processed = 0;
-    int page = 1;
-    int totalPages = 1;
-    boolean limitReached = false;
+    var added = 0;
+    var processed = 0;
+    var page = 1;
+    var totalPages = 1;
+    var limitReached = false;
 
     while (page <= totalPages && page <= JustJoinConnector.MAX_PAGES && !limitReached) {
-      JustJoinConnector.OfferPage p = connector.fetchPage(page);
+      var p = connector.fetchPage(page);
       totalPages = p.totalPages();
 
-      int newOnPage = 0;
-      for (RawJobOffer offer : p.offers()) {
+      var newOnPage = 0;
+      for (var offer : p.offers()) {
         if (limit != null && processed >= limit) {
           limitReached = true;
           break;
         }
-        StoredRawOffer existing = pool.get(offer.id());
-        String firstSeen = existing == null ? now : existing.firstSeenAt();
+        var existing = pool.get(offer.id());
+        var firstSeen = existing == null ? now : existing.firstSeenAt();
         pool.put(offer.id(), new StoredRawOffer(offer, firstSeen));
         if (!knownIds.contains(offer.id())) {
           added++;
@@ -99,8 +99,8 @@ public class ScraperService {
       }
     }
 
-    Instant cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS);
-    List<StoredRawOffer> merged = pool.values().stream()
+    var cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS);
+    var merged = pool.values().stream()
         .filter(stored -> !isExpired(stored, cutoff))
         .toList();
 
@@ -112,7 +112,7 @@ public class ScraperService {
 
   private static void sleepPolitely() {
     try {
-      Thread.sleep(500 + java.util.concurrent.ThreadLocalRandom.current().nextInt(500));
+      Thread.sleep(500 + ThreadLocalRandom.current().nextInt(500));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
@@ -124,7 +124,7 @@ public class ScraperService {
    * is kept (we never drop an offer we can't date).
    */
   private static boolean isExpired(StoredRawOffer stored, Instant cutoff) {
-    Instant reference = parseInstant(stored.offer().publishedAt());
+    var reference = parseInstant(stored.offer().publishedAt());
     if (reference == null) {
       reference = parseInstant(stored.firstSeenAt());
     }
@@ -145,10 +145,10 @@ public class ScraperService {
   /** Returns only offers whose id has not been seen before. Does not persist anything. */
   @Deprecated
   public List<RawJobOffer> scrapeNew() {
-    List<RawJobOffer> all = connector.fetchAll();
-    Set<String> seen = new HashSet<>(repository.readSeenIds());
-    List<RawJobOffer> fresh = new ArrayList<>();
-    for (RawJobOffer offer : all) {
+    var all = connector.fetchAll();
+    var seen = new HashSet<>(repository.readSeenIds());
+    var fresh = new ArrayList<RawJobOffer>();
+    for (var offer : all) {
       if (!seen.contains(offer.id())) {
         fresh.add(offer);
       }

--- a/src/main/java/radar/web/JobController.java
+++ b/src/main/java/radar/web/JobController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import radar.model.JobReport;
-import radar.model.UserProfile;
 import radar.repository.JsonRepository;
 
 /**
@@ -23,19 +22,19 @@ public class JobController {
 
   @GetMapping("/api/jobs")
   public List<JobReport> jobs(@RequestParam(required = false) String date) {
-    String target = date != null ? date : latestDate();
+    var target = date != null ? date : latestDate();
     if (target == null) {
       return List.of();
     }
-    UserProfile profile = repository.readProfile();
-    int minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
+    var profile = repository.readProfile();
+    var minScore = profile.minMatchScore() == null ? 0 : profile.minMatchScore();
     return repository.loadJobs(target).stream()
         .filter(report -> report.matchScore() >= minScore)
         .toList();
   }
 
   private String latestDate() {
-    List<String> dates = repository.listDates(); // ascending
+    var dates = repository.listDates(); // ascending
     return dates.isEmpty() ? null : dates.get(dates.size() - 1);
   }
 }

--- a/src/test/java/radar/connector/JustJoinConnectorTest.java
+++ b/src/test/java/radar/connector/JustJoinConnectorTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import org.junit.jupiter.api.Test;
-import radar.model.RawJobOffer;
 
 /**
  * Unit tests for the JSON-API parsing (no network). Fixtures mirror the shape of
@@ -23,7 +21,7 @@ class JustJoinConnectorTest {
 
   @Test
   void mapsAFullyPopulatedOffer() throws Exception {
-    JsonNode page = json("""
+    var page = json("""
         {
           "meta": {"page": 1, "totalPages": 1},
           "data": [
@@ -45,10 +43,10 @@ class JustJoinConnectorTest {
         }
         """);
 
-    List<RawJobOffer> offers = connector.parseOffers(page);
+    var offers = connector.parseOffers(page);
 
     assertThat(offers).hasSize(1);
-    RawJobOffer o = offers.get(0);
+    var o = offers.get(0);
     assertThat(o.id()).isEqualTo("abc-123");
     assertThat(o.title()).isEqualTo("Senior Java Developer");
     assertThat(o.companyName()).isEqualTo("Acme");
@@ -69,7 +67,7 @@ class JustJoinConnectorTest {
 
   @Test
   void handlesMissingSkillsSalaryAndNonRemote() throws Exception {
-    JsonNode page = json("""
+    var page = json("""
         {
           "meta": {"page": 1, "totalPages": 1},
           "data": [
@@ -88,7 +86,7 @@ class JustJoinConnectorTest {
         }
         """);
 
-    RawJobOffer o = connector.parseOffers(page).get(0);
+    var o = connector.parseOffers(page).get(0);
     assertThat(o.remote()).isFalse();
     assertThat(o.skills()).isEmpty();
     assertThat(o.salaryMin()).isNull();
@@ -99,7 +97,7 @@ class JustJoinConnectorTest {
 
   @Test
   void readsSkillsGivenAsObjects() throws Exception {
-    JsonNode page = json("""
+    var page = json("""
         {
           "data": [
             {
@@ -111,7 +109,7 @@ class JustJoinConnectorTest {
         }
         """);
 
-    RawJobOffer o = connector.parseOffers(page).get(0);
+    var o = connector.parseOffers(page).get(0);
     assertThat(o.skills()).containsExactly("Java", "Kafka");
   }
 

--- a/src/test/java/radar/model/ModelSerializationTest.java
+++ b/src/test/java/radar/model/ModelSerializationTest.java
@@ -15,8 +15,8 @@ class ModelSerializationTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   private <T> void assertRoundTrip(T value, Class<T> type) throws Exception {
-    String json = mapper.writeValueAsString(value);
-    T back = mapper.readValue(json, type);
+    var json = mapper.writeValueAsString(value);
+    var back = mapper.readValue(json, type);
     assertThat(back).isEqualTo(value);
   }
 
@@ -27,7 +27,7 @@ class ModelSerializationTest {
 
   @Test
   void rawJobOfferRoundTrips() throws Exception {
-    RawJobOffer offer = new RawJobOffer(
+    var offer = new RawJobOffer(
         "jj-123", "Senior Java Dev", "Acme", "50-100", "Warsaw", true,
         "2026-07-04", "senior", "Build things", List.of("Java", "Spring"),
         18000, 26000, "PLN", "B2B", "https://justjoin.it/job/jj-123", "justjoin");
@@ -36,7 +36,7 @@ class ModelSerializationTest {
 
   @Test
   void userProfileRoundTrips() throws Exception {
-    UserProfile profile = new UserProfile(
+    var profile = new UserProfile(
         List.of("Java", "Spring Boot"), 3, "B2B", true, 15000, "PLN", "B2B",
         List.of("Warsaw", "Remote"), 6);
     assertRoundTrip(profile, UserProfile.class);
@@ -44,10 +44,10 @@ class ModelSerializationTest {
 
   @Test
   void jobReportRoundTrips() throws Exception {
-    RawJobOffer offer = new RawJobOffer(
+    var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", false, "2026-07-04", "mid",
         "desc", List.of("Java"), 12000, 18000, "PLN", "B2B", "url", "justjoin");
-    JobReport report = new JobReport(
+    var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
         List.of("on-call"), List.of("remote"), "system design", 8,
         new SalaryRange(12000, 18000, "PLN"));
@@ -56,7 +56,7 @@ class ModelSerializationTest {
 
   @Test
   void analyticsRoundTrips() throws Exception {
-    Analytics analytics = new Analytics(
+    var analytics = new Analytics(
         "2026-07-04", 42, Map.of("Java", 30, "Spring", 20), List.of("Acme", "Globex"),
         new SalaryRange(10000, 30000, "PLN"), Map.of("product", 0.6, "outsourcing", 0.4),
         66.7);
@@ -72,23 +72,23 @@ class ModelSerializationTest {
 
   @Test
   void unknownPropertiesAreIgnored() throws Exception {
-    String json = """
+    var json = """
         {"id":"jj-9","title":"Java Dev","unexpectedField":"boom","anotherOne":123}
         """;
-    RawJobOffer offer = mapper.readValue(json, RawJobOffer.class);
+    var offer = mapper.readValue(json, RawJobOffer.class);
     assertThat(offer.id()).isEqualTo("jj-9");
     assertThat(offer.title()).isEqualTo("Java Dev");
   }
 
   @Test
   void withRawJobOfferAttachesOffer() {
-    JobReport report = new JobReport(
+    var report = new JobReport(
         null, List.of("Java"), List.of(), "product", "mid", List.of(), List.of(),
         "focus", 7, new SalaryRange(10000, 20000, "PLN"));
-    RawJobOffer offer = new RawJobOffer(
+    var offer = new RawJobOffer(
         "jj-2", "t", "c", null, null, null, null, null, null, null, null, null,
         null, null, null, null);
-    JobReport attached = report.withRawJobOffer(offer);
+    var attached = report.withRawJobOffer(offer);
     assertThat(attached.rawJobOffer()).isSameAs(offer);
     assertThat(attached.matchScore()).isEqualTo(7);
     assertThat(report.rawJobOffer()).isNull();

--- a/src/test/java/radar/repository/JsonRepositoryTest.java
+++ b/src/test/java/radar/repository/JsonRepositoryTest.java
@@ -37,7 +37,7 @@ class JsonRepositoryTest {
 
   @Test
   void profileRoundTrips() {
-    UserProfile profile = new UserProfile(
+    var profile = new UserProfile(
         List.of("Java", "Spring"), 3, "B2B", true, 15000, "PLN", "B2B",
         List.of("Warsaw", "Remote"), 6);
     repo.writeProfile(profile);
@@ -62,11 +62,11 @@ class JsonRepositoryTest {
 
   @Test
   void jobsRoundTrip() {
-    RawJobOffer offer = new RawJobOffer(
+    var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", true, "2026-07-04", "mid",
         null, List.of("Java"), 12000, 18000, "PLN", "b2b",
         "https://justjoin.it/job-offer/jj-1", "justjoin");
-    JobReport report = new JobReport(
+    var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
         List.of("on-call"), List.of("remote"), "system design", 8,
         new SalaryRange(12000, 18000, "PLN"));
@@ -82,7 +82,7 @@ class JsonRepositoryTest {
 
   @Test
   void analyticsRoundTrip() {
-    Analytics analytics = new Analytics(
+    var analytics = new Analytics(
         "2026-07-04", 42, Map.of("Java", 30, "Spring", 20), List.of("Acme"),
         new SalaryRange(10000, 30000, "PLN"), Map.of("product", 0.6), 66.7);
 

--- a/src/test/java/radar/service/EnricherServiceTest.java
+++ b/src/test/java/radar/service/EnricherServiceTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import radar.model.JobReport;
 import radar.model.RawJobOffer;
 import radar.model.ScanProgress;
 import radar.model.SalaryRange;
@@ -47,7 +46,7 @@ class EnricherServiceTest {
 
   @Test
   void validJsonProducesJobReportWithOfferAttached() {
-    String json = """
+    var json = """
         {
           "keySkills": ["Java", "Spring Boot"],
           "niceToHave": ["Kafka"],
@@ -60,9 +59,9 @@ class EnricherServiceTest {
           "salary": {"min": 18000, "max": 26000, "currency": "PLN"}
         }
         """;
-    RawJobOffer o = offer("jj-1", "Senior Java Dev");
+    var o = offer("jj-1", "Senior Java Dev");
 
-    JobReport report = withCannedJson(json).enrich(o, profile);
+    var report = withCannedJson(json).enrich(o, profile);
 
     assertThat(report.rawJobOffer()).isSameAs(o);
     assertThat(report.keySkills()).containsExactly("Java", "Spring Boot");
@@ -78,11 +77,11 @@ class EnricherServiceTest {
 
   @Test
   void matchScoreIsClampedIntoOneToTenRange() {
-    EnricherService svc = new EnricherService(mock(AnthropicClient.class), mapper);
-    RawJobOffer o = offer("jj-1", "Java Dev");
+    var svc = new EnricherService(mock(AnthropicClient.class), mapper);
+    var o = offer("jj-1", "Java Dev");
 
-    EnrichmentResult tooHigh = result(15);
-    EnrichmentResult tooLow = result(0);
+    var tooHigh = result(15);
+    var tooLow = result(0);
 
     assertThat(svc.toReport(tooHigh, o).matchScore()).isEqualTo(10);
     assertThat(svc.toReport(tooLow, o).matchScore()).isEqualTo(1);
@@ -91,16 +90,16 @@ class EnricherServiceTest {
 
   @Test
   void enrichAllEmitsOneEnrichingProgressPerOffer() {
-    String json = """
+    var json = """
         {"keySkills":[],"niceToHave":[],"projectType":"product","realSeniority":"mid",
          "redFlags":[],"greenFlags":[],"interviewFocus":"basics","matchScore":5,
          "salary":{"min":10000,"max":15000,"currency":"PLN"}}
         """;
-    EnricherService svc = withCannedJson(json);
-    List<RawJobOffer> offers = List.of(offer("a", "A"), offer("b", "B"), offer("c", "C"));
-    List<ScanProgress> events = new ArrayList<>();
+    var svc = withCannedJson(json);
+    var offers = List.of(offer("a", "A"), offer("b", "B"), offer("c", "C"));
+    var events = new ArrayList<ScanProgress>();
 
-    List<JobReport> reports = svc.enrichAll(offers, profile, events::add);
+    var reports = svc.enrichAll(offers, profile, events::add);
 
     assertThat(reports).hasSize(3);
     assertThat(events).hasSize(3);
@@ -111,10 +110,10 @@ class EnricherServiceTest {
 
   @Test
   void promptContainsProfileAndOfferAndNoHtml() {
-    EnricherService svc = new EnricherService(mock(AnthropicClient.class), mapper);
-    RawJobOffer o = offer("jj-1", "Senior Java Dev");
+    var svc = new EnricherService(mock(AnthropicClient.class), mapper);
+    var o = offer("jj-1", "Senior Java Dev");
 
-    String prompt = svc.buildPrompt(o, profile);
+    var prompt = svc.buildPrompt(o, profile);
 
     assertThat(prompt).contains("Senior Java Dev").contains("Acme").contains("Kraków");
     assertThat(prompt).contains("Spring Boot"); // from profile JSON

--- a/src/test/java/radar/service/ReporterServiceTest.java
+++ b/src/test/java/radar/service/ReporterServiceTest.java
@@ -27,7 +27,7 @@ class ReporterServiceTest {
 
   private JobReport report(String company, boolean remote, String projectType, Integer salaryMin,
       List<String> keySkills) {
-    RawJobOffer offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
+    var offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
         "Kraków", remote, "2026-07-04", "senior", null, keySkills, salaryMin,
         salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin");
     return new JobReport(offer, keySkills, List.of(), projectType, "senior", List.of(), List.of(),
@@ -36,14 +36,14 @@ class ReporterServiceTest {
 
   @Test
   void skillFrequencyCountsAndSortsDescending() {
-    List<JobReport> reports = List.of(
+    var reports = List.of(
         report("A", true, "product", 10000, List.of("Java", "Spring")),
         report("B", true, "product", 12000, List.of("Java", "AWS")),
         report("C", false, "outsourcing", 11000, List.of("Java", "Spring")),
         report("D", true, "product", 13000, List.of("Java")),
         report("E", false, "product", 9000, List.of("SQL")));
 
-    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+    var analytics = reporter.buildAnalytics("2026-07-04", reports);
 
     assertThat(analytics.totalScanned()).isEqualTo(5);
     assertThat(analytics.skillFrequency())
@@ -58,27 +58,27 @@ class ReporterServiceTest {
 
   @Test
   void remotePercentageIsBetweenZeroAndHundred() {
-    List<JobReport> reports = List.of(
+    var reports = List.of(
         report("A", true, "product", 10000, List.of("Java")),
         report("B", true, "product", 12000, List.of("Java")),
         report("C", false, "product", 11000, List.of("Java")),
         report("D", false, "product", 13000, List.of("Java")));
 
-    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+    var analytics = reporter.buildAnalytics("2026-07-04", reports);
 
     assertThat(analytics.remotePercentage()).isBetween(0.0, 100.0).isEqualTo(50.0);
   }
 
   @Test
   void topCompaniesRankedByOfferCount() {
-    List<JobReport> reports = List.of(
+    var reports = List.of(
         report("Acme", true, "product", 10000, List.of("Java")),
         report("Acme", true, "product", 12000, List.of("Java")),
         report("Acme", true, "product", 12000, List.of("Java")),
         report("Globex", false, "product", 11000, List.of("Java")),
         report("Initech", false, "product", 9000, List.of("Java")));
 
-    Analytics analytics = reporter.buildAnalytics("2026-07-04", reports);
+    var analytics = reporter.buildAnalytics("2026-07-04", reports);
 
     assertThat(analytics.topCompanies()).first().isEqualTo("Acme");
     assertThat(analytics.topCompanies()).containsExactlyInAnyOrder("Acme", "Globex", "Initech");
@@ -86,12 +86,12 @@ class ReporterServiceTest {
 
   @Test
   void salaryDistributionUsesMinAndMaxOfSalaryMins() {
-    List<JobReport> reports = List.of(
+    var reports = List.of(
         report("A", true, "product", 9000, List.of("Java")),
         report("B", true, "product", 18000, List.of("Java")),
         report("C", false, "product", 12000, List.of("Java")));
 
-    SalaryRange dist = reporter.buildAnalytics("2026-07-04", reports).salaryDistribution();
+    var dist = reporter.buildAnalytics("2026-07-04", reports).salaryDistribution();
 
     assertThat(dist.min()).isEqualTo(9000);
     assertThat(dist.max()).isEqualTo(18000);
@@ -100,13 +100,13 @@ class ReporterServiceTest {
 
   @Test
   void projectTypeBreakdownSumsToAround100Percent() {
-    List<JobReport> reports = List.of(
+    var reports = List.of(
         report("A", true, "product", 10000, List.of("Java")),
         report("B", true, "product", 12000, List.of("Java")),
         report("C", false, "outsourcing", 11000, List.of("Java")),
         report("D", true, "product", 13000, List.of("Java")));
 
-    Map<String, Double> breakdown = reporter.buildAnalytics("2026-07-04", reports)
+    var breakdown = reporter.buildAnalytics("2026-07-04", reports)
         .projectTypeBreakdown();
 
     assertThat(breakdown.get("product")).isEqualTo(75.0);
@@ -120,7 +120,7 @@ class ReporterServiceTest {
     when(repository.loadAnalytics("2026-07-04")).thenReturn(analytics(Map.of("Java", 3, "Spring", 2)));
     when(repository.loadAnalytics("2026-07-05")).thenReturn(analytics(Map.of("Java", 5, "AWS", 1)));
 
-    Map<String, Integer> trends = reporter.computeTrends();
+    var trends = reporter.computeTrends();
 
     assertThat(trends).isNotEmpty();
     assertThat(trends).containsExactly(

--- a/src/test/java/radar/service/ScanServiceTest.java
+++ b/src/test/java/radar/service/ScanServiceTest.java
@@ -66,11 +66,11 @@ class ScanServiceTest {
 
   @Test
   void runScanEmitsEventsInOrderAndPersistsFilteredResults() {
-    RawJobOffer a = offer("a");
-    RawJobOffer b = offer("b");
-    JobReport good = report(a, 8); // >= minMatchScore 6
-    JobReport weak = report(b, 4); // filtered out
-    Analytics analytics = new Analytics("2026-07-04", 2, java.util.Map.of("Java", 2), List.of(),
+    var a = offer("a");
+    var b = offer("b");
+    var good = report(a, 8); // >= minMatchScore 6
+    var weak = report(b, 4); // filtered out
+    var analytics = new Analytics("2026-07-04", 2, java.util.Map.of("Java", 2), List.of(),
         null, java.util.Map.of(), 100.0);
 
     when(repository.readProfile()).thenReturn(profile);
@@ -92,23 +92,23 @@ class ScanServiceTest {
         ScanProgress.Type.SAVING, ScanProgress.Type.DONE);
 
     // only the offer meeting minMatchScore is saved as jobs; analytics saved regardless
-    ArgumentCaptor<List<JobReport>> jobs = ArgumentCaptor.forClass(List.class);
+    var jobs = ArgumentCaptor.forClass(List.class);
     verify(repository).saveJobs(anyString(), jobs.capture());
     assertThat(jobs.getValue()).containsExactly(good);
     verify(repository).saveAnalytics(anyString(), eq(analytics));
     verify(scraper).markAsSeen(List.of("a", "b"));
     verify(emitter).complete();
 
-    ScanProgress done = emitted.get(emitted.size() - 1);
+    var done = emitted.get(emitted.size() - 1);
     assertThat(done.saved()).isEqualTo(1);
     assertThat(done.total()).isEqualTo(2);
   }
 
   @Test
   void runScanSavesAnalyticsEvenWhenNothingPassesFilter() {
-    RawJobOffer a = offer("a");
-    JobReport weak = report(a, 3);
-    Analytics analytics = new Analytics("2026-07-04", 1, java.util.Map.of(), List.of(), null,
+    var a = offer("a");
+    var weak = report(a, 3);
+    var analytics = new Analytics("2026-07-04", 1, java.util.Map.of(), List.of(), null,
         java.util.Map.of(), 100.0);
 
     when(repository.readProfile()).thenReturn(profile);
@@ -118,7 +118,7 @@ class ScanServiceTest {
 
     scanService.runScan(emitter, null);
 
-    ArgumentCaptor<List<JobReport>> jobs = ArgumentCaptor.forClass(List.class);
+    var jobs = ArgumentCaptor.forClass(List.class);
     verify(repository).saveJobs(anyString(), jobs.capture());
     assertThat(jobs.getValue()).isEmpty();
     verify(repository).saveAnalytics(anyString(), eq(analytics));
@@ -128,7 +128,7 @@ class ScanServiceTest {
   @Test
   void runScanEmitsErrorAndCompletesWithErrorOnFailure() {
     when(repository.readProfile()).thenReturn(profile);
-    RuntimeException boom = new RuntimeException("scrape failed");
+    var boom = new RuntimeException("scrape failed");
     when(scraper.scrapeNew()).thenThrow(boom);
 
     scanService.runScan(emitter, null);
@@ -142,15 +142,15 @@ class ScanServiceTest {
 
   @Test
   void runScanCapsEnrichmentAndSeenIdsToLimit() {
-    RawJobOffer a = offer("a");
-    RawJobOffer b = offer("b");
-    RawJobOffer c = offer("c");
-    Analytics analytics = new Analytics("2026-07-04", 2, java.util.Map.of(), List.of(), null,
+    var a = offer("a");
+    var b = offer("b");
+    var c = offer("c");
+    var analytics = new Analytics("2026-07-04", 2, java.util.Map.of(), List.of(), null,
         java.util.Map.of(), 100.0);
 
     when(repository.readProfile()).thenReturn(profile);
     when(scraper.scrapeNew()).thenReturn(List.of(a, b, c));
-    ArgumentCaptor<List<RawJobOffer>> enriched = ArgumentCaptor.forClass(List.class);
+    var enriched = ArgumentCaptor.forClass(List.class);
     when(enricher.enrichAll(enriched.capture(), any(), any()))
         .thenReturn(List.of(report(a, 8), report(b, 7)));
     when(reporter.buildAnalytics(anyString(), anyList())).thenReturn(analytics);
@@ -160,7 +160,7 @@ class ScanServiceTest {
     // only the first 2 offers are enriched and marked seen; the third is left for a later run
     assertThat(enriched.getValue()).containsExactly(a, b);
     verify(scraper).markAsSeen(List.of("a", "b"));
-    ScanProgress done = emitted.get(emitted.size() - 1);
+    var done = emitted.get(emitted.size() - 1);
     assertThat(done.type()).isEqualTo(ScanProgress.Type.DONE);
     assertThat(done.total()).isEqualTo(2);
   }

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -54,7 +54,7 @@ class WebControllersTest {
   }
 
   private JobReport report(String id, int score) {
-    RawJobOffer offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
+    var offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
         "senior", null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin");
     return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
         List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));


### PR DESCRIPTION
## What

Adopt Java 25 local-variable type inference (`var`) across the codebase, and record it as a project rule so future code follows it.

## Changes

- **Rule**: `.claude/rules/code-style.md` (always `var` for locals where the compiler allows; not `final var`) + a pointer in `CLAUDE.md`.
- **Code**: converted local variables and enhanced-for variables to `var` across main (`JsonRepository`, `ScraperService`, `JustJoinConnector`, `EnricherService`, `ReporterService`, `ScanService`, `JobController`) and all affected tests.
- **Imports**: removed types left unused once explicit local types were dropped.

## Kept explicit on purpose

- No-initializer declarations (`Analytics analytics;` assigned in a `try`).
- Mockito `inv.getArgument(2)` — needs a target type or it infers `Object`.
- Fields, parameters, return types, record components (`var` not legal there).

## Verification

No behavior change. `./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)