### PR TITLE
feat(offers): VR-34 delete-jobs endpoint and offer-details foundation

### DIFF
--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -1,7 +1,17 @@
 # Key Models
 
 ## RawJobOffer
-`id, title, companyName, companySize, location, remote, publishedAt, experienceLevel, description, skills, salaryMin, salaryMax, currency, contractType, applyUrl, sourceConnector`
+`id, title, companyName, companySize, location, remote, publishedAt, experienceLevel, description, skills, salaryMin, salaryMax, currency, contractType, applyUrl, sourceConnector, domain`
+
+- `description` and `domain` come from the offer's own page (details step), not the listing API — `null` until fetched. `RawJobOffer.withDetails(description, domain)` returns an enriched copy.
+
+## StoredRawOffer (element of `raw-offers.json`)
+`offer (RawJobOffer), firstSeenAt, detailsFetchedAt`
+
+- Profile-independent scraped pool. `detailsFetchedAt` is `null` until the details step fetches the page; the step processes only null entries.
+
+## OfferDetails
+`description, domain` — the "as written" fields lifted from an offer page's JobPosting JSON-LD (no AI). Produced by `OfferDetailsParser`.
 
 ## UserProfile (`data/profile.json`)
 `currentSkills, experienceYears, preferredType, preferredRemote, salaryMin, currency, contractType, locations, minMatchScore`

--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -151,7 +151,8 @@ public class JustJoinConnector {
         upperOrNull(salary, "currency"),
         textOrNull(salary, "type"),
         slug == null ? null : "https://justjoin.it/job-offer/" + slug,
-        SOURCE);
+        SOURCE,
+        null); // domain — filled by the details step, not the list API
   }
 
   private static List<String> readSkills(JsonNode skillsNode) {

--- a/src/main/java/radar/connector/OfferDetailsParser.java
+++ b/src/main/java/radar/connector/OfferDetailsParser.java
@@ -1,0 +1,74 @@
+package radar.connector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
+import org.springframework.stereotype.Component;
+import radar.model.OfferDetails;
+
+/**
+ * Extracts the "as written" details from a JustJoin offer page — no AI, and no HTML ever leaves the
+ * app. The page embeds a schema.org {@code JobPosting} as a {@code <script type="application/ld+json">}
+ * block; we read its full {@code description} text and the hiring company's domain (from
+ * {@code hiringOrganization.sameAs}).
+ */
+@Component
+public class OfferDetailsParser {
+
+  private final ObjectMapper objectMapper;
+
+  public OfferDetailsParser(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Parses page HTML into {@link OfferDetails}. Returns an all-null result when the page carries no
+   * JobPosting JSON-LD block.
+   */
+  public OfferDetails parse(String html) {
+    var doc = Jsoup.parse(html);
+    for (var script : doc.select("script[type=application/ld+json]")) {
+      var node = readJson(script.data());
+      if (node != null && "JobPosting".equals(node.path("@type").asText())) {
+        var description = text(node.path("description"));
+        var domain = domainFrom(node.path("hiringOrganization").path("sameAs").asText(null));
+        return new OfferDetails(description, domain);
+      }
+    }
+    return new OfferDetails(null, null);
+  }
+
+  private JsonNode readJson(String json) {
+    try {
+      return objectMapper.readTree(json);
+    } catch (Exception e) {
+      return null; // not valid JSON — skip this block
+    }
+  }
+
+  /** Decodes HTML entities (e.g. {@code &apos;}) in the text while preserving newlines. */
+  private static String text(JsonNode node) {
+    if (node.isMissingNode() || node.isNull()) {
+      return null;
+    }
+    var raw = node.asText();
+    return raw.isBlank() ? null : Parser.unescapeEntities(raw, false);
+  }
+
+  private static String domainFrom(String url) {
+    if (url == null || url.isBlank()) {
+      return null;
+    }
+    try {
+      var host = URI.create(url.trim()).getHost();
+      if (host == null) {
+        return null;
+      }
+      return host.startsWith("www.") ? host.substring(4) : host;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/radar/model/OfferDetails.java
+++ b/src/main/java/radar/model/OfferDetails.java
@@ -1,0 +1,8 @@
+package radar.model;
+
+/**
+ * The "as written" details lifted from an offer's own page (no AI): the full job description text and
+ * the hiring company's domain. Either field may be {@code null} if the page didn't carry it.
+ */
+public record OfferDetails(String description, String domain) {
+}

--- a/src/main/java/radar/model/RawJobOffer.java
+++ b/src/main/java/radar/model/RawJobOffer.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 /**
  * A raw job offer as scraped from a source connector (e.g. JustJoin), before enrichment.
+ *
+ * <p>{@code description} and {@code domain} come from the offer's own page (the details step),
+ * not the listing API — they are {@code null} on a freshly-scraped offer and filled in later.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record RawJobOffer(
@@ -23,6 +26,17 @@ public record RawJobOffer(
     String currency,
     String contractType,
     String applyUrl,
-    String sourceConnector
+    String sourceConnector,
+    String domain
 ) {
+
+  /**
+   * Returns a copy with the detail-page fields filled in: the full {@code description} text and the
+   * company {@code domain}. Everything else is preserved.
+   */
+  public RawJobOffer withDetails(String description, String domain) {
+    return new RawJobOffer(id, title, companyName, companySize, location, remote, publishedAt,
+        experienceLevel, description, skills, salaryMin, salaryMax, currency, contractType,
+        applyUrl, sourceConnector, domain);
+  }
 }

--- a/src/main/java/radar/model/StoredRawOffer.java
+++ b/src/main/java/radar/model/StoredRawOffer.java
@@ -1,14 +1,30 @@
 package radar.model;
 
 /**
- * A raw offer as persisted in {@code raw-offers.json}, together with the timestamp it was first
- * scraped. The wrapper keeps {@link RawJobOffer} itself profile-independent: enrichment (matchScore
- * and everything derived from a user profile) lives on {@code JobReport}, never here.
+ * A raw offer as persisted in {@code raw-offers.json}, together with scan/detail bookkeeping. The
+ * wrapper keeps {@link RawJobOffer} itself profile-independent: enrichment (matchScore and everything
+ * derived from a user profile) lives on {@code JobReport}, never here.
  *
- * @param offer       the scraped offer, unchanged
- * @param firstSeenAt ISO-8601 instant of the first scan that saw this offer; used for retention.
- *                    Stored as a String because the shared Jackson 2 {@code ObjectMapper} has no
- *                    java.time module registered.
+ * @param offer            the scraped offer (its {@code description}/{@code domain} are null until
+ *                         the details step fills them)
+ * @param firstSeenAt      ISO-8601 instant of the first scan that saw this offer; used for retention
+ * @param detailsFetchedAt ISO-8601 instant the offer's page details were fetched, or {@code null} if
+ *                         not fetched yet — the details step processes only null entries
  */
-public record StoredRawOffer(RawJobOffer offer, String firstSeenAt) {
+public record StoredRawOffer(RawJobOffer offer, String firstSeenAt, String detailsFetchedAt) {
+
+  /** A just-scraped offer with no page details fetched yet. */
+  public static StoredRawOffer fresh(RawJobOffer offer, String firstSeenAt) {
+    return new StoredRawOffer(offer, firstSeenAt, null);
+  }
+
+  /** Whether the offer's page details (full description, domain) have been fetched. */
+  public boolean hasDetails() {
+    return detailsFetchedAt != null;
+  }
+
+  /** Returns a copy with page details applied to the offer and {@code detailsFetchedAt} stamped. */
+  public StoredRawOffer withDetails(String description, String domain, String fetchedAt) {
+    return new StoredRawOffer(offer.withDetails(description, domain), firstSeenAt, fetchedAt);
+  }
 }

--- a/src/main/java/radar/repository/JsonRepository.java
+++ b/src/main/java/radar/repository/JsonRepository.java
@@ -141,6 +141,24 @@ public class JsonRepository {
     }
   }
 
+  /** Deletes {@code jobs.json} from every date snapshot. Returns how many files were removed. */
+  public int deleteAllJobs() {
+    var deleted = 0;
+    for (var date : listDates()) {
+      lock.writeLock().lock();
+      try {
+        if (Files.deleteIfExists(dateDir(date).resolve(JOBS_FILE))) {
+          deleted++;
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to delete jobs for " + date, e);
+      } finally {
+        lock.writeLock().unlock();
+      }
+    }
+    return deleted;
+  }
+
   // ---- analytics ----
 
   public void saveAnalytics(String date, Analytics analytics) {

--- a/src/main/java/radar/service/ScraperService.java
+++ b/src/main/java/radar/service/ScraperService.java
@@ -79,11 +79,16 @@ public class ScraperService {
           break;
         }
         var existing = pool.get(offer.id());
-        var firstSeen = existing == null ? now : existing.firstSeenAt();
-        pool.put(offer.id(), new StoredRawOffer(offer, firstSeen));
-        if (!knownIds.contains(offer.id())) {
+        if (existing == null) {
+          pool.put(offer.id(), StoredRawOffer.fresh(offer, now));
           added++;
           newOnPage++;
+        } else {
+          // Refresh list fields (salary/title may change) but keep already-fetched page details
+          // and their timestamps — the list API never carries description/domain.
+          var refreshed = offer.withDetails(existing.offer().description(), existing.offer().domain());
+          pool.put(offer.id(),
+              new StoredRawOffer(refreshed, existing.firstSeenAt(), existing.detailsFetchedAt()));
         }
         processed++;
       }

--- a/src/main/java/radar/web/JobController.java
+++ b/src/main/java/radar/web/JobController.java
@@ -1,6 +1,8 @@
 package radar.web;
 
 import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +33,12 @@ public class JobController {
     return repository.loadJobs(target).stream()
         .filter(report -> report.matchScore() >= minScore)
         .toList();
+  }
+
+  /** Deletes all saved job reports across every snapshot. Returns how many files were removed. */
+  @DeleteMapping("/api/jobs")
+  public Map<String, Integer> deleteAll() {
+    return Map.of("deleted", repository.deleteAllJobs());
   }
 
   private String latestDate() {

--- a/src/test/java/radar/connector/OfferDetailsParserTest.java
+++ b/src/test/java/radar/connector/OfferDetailsParserTest.java
@@ -1,0 +1,39 @@
+package radar.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Parses the JobPosting JSON-LD out of an offer page — no network, uses a bundled fixture. */
+class OfferDetailsParserTest {
+
+  private final OfferDetailsParser parser = new OfferDetailsParser(new ObjectMapper());
+
+  private String fixture() throws Exception {
+    try (var in = getClass().getResourceAsStream("/offer-page.html")) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  void extractsDescriptionAndDomainFromJobPostingLdJson() throws Exception {
+    var details = parser.parse(fixture());
+
+    // picks the JobPosting block, not the WebSite one
+    assertThat(details.description()).contains("You will build data streams.");
+    assertThat(details.description()).contains("Responsibilities you'll have"); // &apos; decoded
+    assertThat(details.description()).contains("\n"); // newlines preserved
+    // domain from hiringOrganization.sameAs, with www. stripped
+    assertThat(details.domain()).isEqualTo("jit.team");
+  }
+
+  @Test
+  void returnsNullsWhenNoJobPostingPresent() {
+    var details = parser.parse("<html><head></head><body>no ld+json here</body></html>");
+
+    assertThat(details.description()).isNull();
+    assertThat(details.domain()).isNull();
+  }
+}

--- a/src/test/java/radar/model/ModelSerializationTest.java
+++ b/src/test/java/radar/model/ModelSerializationTest.java
@@ -30,7 +30,7 @@ class ModelSerializationTest {
     var offer = new RawJobOffer(
         "jj-123", "Senior Java Dev", "Acme", "50-100", "Warsaw", true,
         "2026-07-04", "senior", "Build things", List.of("Java", "Spring"),
-        18000, 26000, "PLN", "B2B", "https://justjoin.it/job/jj-123", "justjoin");
+        18000, 26000, "PLN", "B2B", "https://justjoin.it/job/jj-123", "justjoin", null);
     assertRoundTrip(offer, RawJobOffer.class);
   }
 
@@ -46,7 +46,7 @@ class ModelSerializationTest {
   void jobReportRoundTrips() throws Exception {
     var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", false, "2026-07-04", "mid",
-        "desc", List.of("Java"), 12000, 18000, "PLN", "B2B", "url", "justjoin");
+        "desc", List.of("Java"), 12000, 18000, "PLN", "B2B", "url", "justjoin", null);
     var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
         List.of("on-call"), List.of("remote"), "system design", 8,
@@ -87,7 +87,7 @@ class ModelSerializationTest {
         "focus", 7, new SalaryRange(10000, 20000, "PLN"));
     var offer = new RawJobOffer(
         "jj-2", "t", "c", null, null, null, null, null, null, null, null, null,
-        null, null, null, null);
+        null, null, null, null, null);
     var attached = report.withRawJobOffer(offer);
     assertThat(attached.rawJobOffer()).isSameAs(offer);
     assertThat(attached.matchScore()).isEqualTo(7);

--- a/src/test/java/radar/repository/JsonRepositoryTest.java
+++ b/src/test/java/radar/repository/JsonRepositoryTest.java
@@ -65,7 +65,7 @@ class JsonRepositoryTest {
     var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", true, "2026-07-04", "mid",
         null, List.of("Java"), 12000, 18000, "PLN", "b2b",
-        "https://justjoin.it/job-offer/jj-1", "justjoin");
+        "https://justjoin.it/job-offer/jj-1", "justjoin", null);
     var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
         List.of("on-call"), List.of("remote"), "system design", 8,
@@ -78,6 +78,26 @@ class JsonRepositoryTest {
   @Test
   void loadJobsReturnsEmptyWhenMissing() {
     assertThat(repo.loadJobs("2026-01-01")).isEmpty();
+  }
+
+  @Test
+  void deleteAllJobsRemovesEverySnapshotsJobsFile() {
+    var report = new JobReport(
+        new RawJobOffer("jj-1", "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
+            null, List.of("Java"), 12000, 18000, "PLN", "b2b", "url", "justjoin", null),
+        List.of("Java"), List.of(), "product", "mid", List.of(), List.of(), "focus", 8,
+        new SalaryRange(12000, 18000, "PLN"));
+    repo.saveJobs("2026-07-04", List.of(report));
+    repo.saveJobs("2026-07-05", List.of(report));
+    // a snapshot with only analytics (no jobs.json) must not be counted
+    repo.saveAnalytics("2026-07-06",
+        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+
+    var deleted = repo.deleteAllJobs();
+
+    assertThat(deleted).isEqualTo(2);
+    assertThat(repo.loadJobs("2026-07-04")).isEmpty();
+    assertThat(repo.loadJobs("2026-07-05")).isEmpty();
   }
 
   @Test

--- a/src/test/java/radar/service/EnricherServiceTest.java
+++ b/src/test/java/radar/service/EnricherServiceTest.java
@@ -24,7 +24,7 @@ class EnricherServiceTest {
   private RawJobOffer offer(String id, String title) {
     return new RawJobOffer(id, title, "Acme", null, "Kraków", true, "2026-07-04", "senior",
         null, List.of("Java", "AWS"), 18000, 26000, "PLN", "b2b",
-        "https://justjoin.it/job-offer/" + id, "justjoin");
+        "https://justjoin.it/job-offer/" + id, "justjoin", null);
   }
 
   /**

--- a/src/test/java/radar/service/ReporterServiceTest.java
+++ b/src/test/java/radar/service/ReporterServiceTest.java
@@ -29,7 +29,7 @@ class ReporterServiceTest {
       List<String> keySkills) {
     var offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
         "Kraków", remote, "2026-07-04", "senior", null, keySkills, salaryMin,
-        salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin");
+        salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin", null);
     return new JobReport(offer, keySkills, List.of(), projectType, "senior", List.of(), List.of(),
         "focus", 7, new SalaryRange(salaryMin, salaryMin == null ? null : salaryMin + 5000, "PLN"));
   }

--- a/src/test/java/radar/service/ScanServiceTest.java
+++ b/src/test/java/radar/service/ScanServiceTest.java
@@ -56,7 +56,7 @@ class ScanServiceTest {
 
   private RawJobOffer offer(String id) {
     return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "senior",
-        null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin");
+        null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin", null);
   }
 
   private JobReport report(RawJobOffer offer, int score) {

--- a/src/test/java/radar/service/ScraperServiceTest.java
+++ b/src/test/java/radar/service/ScraperServiceTest.java
@@ -43,11 +43,11 @@ class ScraperServiceTest {
   private RawJobOffer offer(String id) {
     return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
         null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
-        "justjoin");
+        "justjoin", null);
   }
 
   private StoredRawOffer stored(String id, String firstSeenAt) {
-    return new StoredRawOffer(offer(id), firstSeenAt);
+    return new StoredRawOffer(offer(id), firstSeenAt, null);
   }
 
   private OfferPage page(int totalPages, String... ids) {

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -55,7 +56,7 @@ class WebControllersTest {
 
   private JobReport report(String id, int score) {
     var offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
-        "senior", null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin");
+        "senior", null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin", null);
     return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
         List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));
   }
@@ -104,6 +105,16 @@ class WebControllersTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].rawJobOffer.id").value("x"));
     verify(repository).loadJobs("2026-07-01");
+  }
+
+  @Test
+  void deleteJobsReturnsRemovedCount() throws Exception {
+    when(repository.deleteAllJobs()).thenReturn(3);
+
+    mvc.perform(delete("/api/jobs"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.deleted").value(3));
+    verify(repository).deleteAllJobs();
   }
 
   @Test

--- a/src/test/resources/offer-page.html
+++ b/src/test/resources/offer-page.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+  <script type="application/json">{"tenant":"JJIT","language":"en"}</script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"WebSite","name":"JustJoin"}
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"JobPosting","title":"Senior Java Developer","description":"Project\nYou will build data streams.\n\nResponsibilities you&apos;ll have\nWrite Java.","hiringOrganization":{"@type":"Organization","name":"Jit Team","sameAs":"https://www.jit.team"}}
+  </script>
+</head>
+<body><h1>Senior Java Developer</h1></body>
+</html>


### PR DESCRIPTION
Two pieces committed together (their test-file changes are intertwined via `RawJobOffer` constructor updates).

## Delete jobs
- `JsonRepository.deleteAllJobs()` — removes `jobs.json` from every snapshot.
- `DELETE /api/jobs` → `{"deleted": N}`. Verified live (deleted 1).

## Offer-details foundation (Stage 2 — no AI yet)
- `RawJobOffer` gains a `domain` field; `description` + `domain` are detail-page sourced (`null` until fetched). `withDetails(description, domain)` copy helper.
- `StoredRawOffer` gains `detailsFetchedAt` (+ `fresh`/`hasDetails`/`withDetails`) — the details step will process only `null` entries.
- `ScraperService` merge now **preserves fetched details on re-scan** instead of clobbering them with the list API's nulls.
- `OfferDetails` model + `OfferDetailsParser`: pulls the full `description` text and company `domain` from the page's `JobPosting` JSON-LD (Jsoup + Jackson, HTML entities decoded, `www.` stripped).
- Parser unit test against a bundled `offer-page.html` fixture.
- `models.md` updated.

## Not wired yet
Fetching details into the pool (`OfferDetailsService`) and running it from `scan` are the next chunk, followed by Stage 3 (evaluate).

`./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)