### PR TITLE
feat(scan): VR-36 fetch offer page details during scan

### DIFF
--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -93,6 +93,34 @@ public class JustJoinConnector {
     return new OfferPage(parseOffers(root), totalPages);
   }
 
+  /**
+   * Fetches the raw HTML of a single offer's page (e.g. {@code applyUrl}). The offer detail — full
+   * description and company domain — lives in a JSON-LD block on this page; parsing is done elsewhere
+   * ({@code OfferDetailsParser}). Never sends any of this to Claude.
+   */
+  public String fetchOfferPageHtml(String url) {
+    var request = HttpRequest.newBuilder(URI.create(url))
+        .header("User-Agent", USER_AGENT)
+        .header("Accept", "text/html")
+        .header("Referer", "https://justjoin.it/")
+        .timeout(Duration.ofSeconds(30))
+        .GET()
+        .build();
+    try {
+      var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new IllegalStateException(
+            "Offer page returned HTTP " + response.statusCode() + " for " + url);
+      }
+      return response.body();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to fetch offer page " + url, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted fetching offer page " + url, e);
+    }
+  }
+
   private JsonNode fetchPageJson(int page) {
     var url = API_BASE + "?categories%5B%5D=" + JAVA_CATEGORY_ID + "&page=" + page + "&perPage="
         + PER_PAGE + "&sortBy=published&orderBy=DESC";

--- a/src/main/java/radar/model/DetailsResult.java
+++ b/src/main/java/radar/model/DetailsResult.java
@@ -1,0 +1,8 @@
+package radar.model;
+
+/**
+ * Outcome of the details step: how many offers had their page details fetched this run, and how many
+ * still lack details afterwards (skipped by the limit or left after a fetch failure).
+ */
+public record DetailsResult(int fetched, int remaining) {
+}

--- a/src/main/java/radar/model/ScanResponse.java
+++ b/src/main/java/radar/model/ScanResponse.java
@@ -1,0 +1,12 @@
+package radar.model;
+
+/**
+ * Combined result of a scan: the scrape ({@code added}/{@code total}) plus the details step
+ * ({@code detailsFetched}/{@code detailsRemaining}).
+ */
+public record ScanResponse(int added, int total, int detailsFetched, int detailsRemaining) {
+
+  public static ScanResponse of(ScanResult scan, DetailsResult details) {
+    return new ScanResponse(scan.added(), scan.total(), details.fetched(), details.remaining());
+  }
+}

--- a/src/main/java/radar/service/OfferDetailsService.java
+++ b/src/main/java/radar/service/OfferDetailsService.java
@@ -1,0 +1,83 @@
+package radar.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import radar.connector.JustJoinConnector;
+import radar.connector.OfferDetailsParser;
+import radar.model.DetailsResult;
+import radar.repository.JsonRepository;
+
+/**
+ * Fills in offer page details (full description + company domain) for pooled offers that don't have
+ * them yet. Reads {@code raw-offers.json}, fetches each pending offer's page, parses the JobPosting
+ * JSON-LD, and writes the enriched pool back. Incremental (only {@code detailsFetchedAt == null}
+ * offers), bounded by {@code limit}, and never calls Claude.
+ */
+@Service
+public class OfferDetailsService {
+
+  private static final Logger log = LoggerFactory.getLogger(OfferDetailsService.class);
+
+  private final JustJoinConnector connector;
+  private final OfferDetailsParser parser;
+  private final JsonRepository repository;
+
+  public OfferDetailsService(JustJoinConnector connector, OfferDetailsParser parser,
+      JsonRepository repository) {
+    this.connector = connector;
+    this.parser = parser;
+    this.repository = repository;
+  }
+
+  /**
+   * Fetches page details for offers still missing them.
+   *
+   * @param limit optional cap on how many offers to fetch this run; {@code null} = no cap. Offers a
+   *              fetch fails on are left for a later run.
+   */
+  public DetailsResult fetchMissing(Integer limit) {
+    var pool = repository.readRawOffers();
+    var updated = new ArrayList<>(pool);
+    var fetched = 0;
+    var missing = 0;
+
+    for (var i = 0; i < updated.size(); i++) {
+      var stored = updated.get(i);
+      if (stored.hasDetails() || stored.offer().applyUrl() == null) {
+        continue;
+      }
+      missing++;
+      if (limit != null && fetched >= limit) {
+        continue; // leave for a later run
+      }
+      try {
+        var html = connector.fetchOfferPageHtml(stored.offer().applyUrl());
+        var details = parser.parse(html);
+        updated.set(i, stored.withDetails(details.description(), details.domain(),
+            Instant.now().toString()));
+        fetched++;
+      } catch (RuntimeException e) {
+        log.warn("Details fetch failed for {}: {}", stored.offer().id(), e.toString());
+      }
+      sleepPolitely();
+    }
+
+    repository.saveRawOffers(updated);
+    var remaining = missing - fetched;
+    log.info("Details: fetched {}, remaining {} (limit={})", fetched, remaining, limit);
+    return new DetailsResult(fetched, remaining);
+  }
+
+  /** Rate-limits between page fetches. Package-private/overridable so tests can run without sleeping. */
+  void sleepPolitely() {
+    try {
+      Thread.sleep(500 + ThreadLocalRandom.current().nextInt(500));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/main/java/radar/web/ScanController.java
+++ b/src/main/java/radar/web/ScanController.java
@@ -3,34 +3,38 @@ package radar.web;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import radar.model.ScanResult;
+import radar.model.ScanResponse;
+import radar.service.OfferDetailsService;
 import radar.service.ScraperService;
 
 /**
- * Triggers a scrape. Scraping is fast (no enrichment, no Claude), so this endpoint runs
- * synchronously and returns the {@link ScanResult} directly. Enrichment/evaluation is a separate
- * endpoint.
+ * Runs a scan: scrape the listing into the raw-offers pool, then fetch page details for offers that
+ * don't have them yet. No Claude here — enrichment/evaluation is a separate step. Synchronous; use
+ * {@code limit} to bound heavy runs.
  */
 @RestController
 public class ScanController {
 
   private final ScraperService scraperService;
+  private final OfferDetailsService offerDetailsService;
 
-  public ScanController(ScraperService scraperService) {
+  public ScanController(ScraperService scraperService, OfferDetailsService offerDetailsService) {
     this.scraperService = scraperService;
+    this.offerDetailsService = offerDetailsService;
   }
 
   /**
-   * Fetches current offers into the raw-offers pool and returns how many were added / the total.
-   *
-   * @param fullFetch walk every page to refresh the whole pool; default {@code false} stops early
-   *                  once a page brings nothing new (cheap incremental scan)
-   * @param limit     cap on how many offers to process this run (newest first); omit for no cap
+   * @param fullFetch walk every listing page to refresh the whole pool; default {@code false} stops
+   *                  early once a page brings nothing new
+   * @param limit     caps both the scrape (newest N) and the details fetch (N pending) this run;
+   *                  omit for no cap
    */
   @PostMapping("/api/scan")
-  public ScanResult scan(
+  public ScanResponse scan(
       @RequestParam(defaultValue = "false") boolean fullFetch,
       @RequestParam(required = false) Integer limit) {
-    return scraperService.scan(fullFetch, limit);
+    var scan = scraperService.scan(fullFetch, limit);
+    var details = offerDetailsService.fetchMissing(limit);
+    return ScanResponse.of(scan, details);
   }
 }

--- a/src/test/java/radar/service/OfferDetailsServiceTest.java
+++ b/src/test/java/radar/service/OfferDetailsServiceTest.java
@@ -1,0 +1,128 @@
+package radar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import radar.connector.JustJoinConnector;
+import radar.connector.OfferDetailsParser;
+import radar.model.OfferDetails;
+import radar.model.RawJobOffer;
+import radar.model.StoredRawOffer;
+import radar.repository.JsonRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OfferDetailsServiceTest {
+
+  @Mock
+  JustJoinConnector connector;
+
+  @Mock
+  OfferDetailsParser parser;
+
+  @Mock
+  JsonRepository repository;
+
+  OfferDetailsService service;
+
+  @BeforeEach
+  void setUp() {
+    // override the polite sleep so the test doesn't actually wait
+    service = new OfferDetailsService(connector, parser, repository) {
+      @Override
+      void sleepPolitely() {
+      }
+    };
+  }
+
+  private RawJobOffer offer(String id) {
+    return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
+        null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
+        "justjoin", null);
+  }
+
+  private String url(String id) {
+    return "https://justjoin.it/job-offer/" + id;
+  }
+
+  private StoredRawOffer pending(String id) {
+    return StoredRawOffer.fresh(offer(id), "2026-07-05T10:00:00Z");
+  }
+
+  private StoredRawOffer withDetails(String id) {
+    return new StoredRawOffer(offer(id).withDetails("existing", "acme.com"),
+        "2026-07-05T10:00:00Z", "2026-07-05T11:00:00Z");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<StoredRawOffer> capturePersisted() {
+    ArgumentCaptor<List<StoredRawOffer>> captor = ArgumentCaptor.forClass(List.class);
+    verify(repository).saveRawOffers(captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void fillsDescriptionAndDomainForOffersLackingDetails() {
+    when(repository.readRawOffers()).thenReturn(List.of(pending("a"), pending("b")));
+    when(connector.fetchOfferPageHtml(url("a"))).thenReturn("<a>");
+    when(connector.fetchOfferPageHtml(url("b"))).thenReturn("<b>");
+    when(parser.parse("<a>")).thenReturn(new OfferDetails("desc a", "a.com"));
+    when(parser.parse("<b>")).thenReturn(new OfferDetails("desc b", "b.com"));
+
+    var result = service.fetchMissing(null);
+
+    assertThat(result.fetched()).isEqualTo(2);
+    assertThat(result.remaining()).isEqualTo(0);
+    var saved = capturePersisted();
+    assertThat(saved).allSatisfy(s -> assertThat(s.hasDetails()).isTrue());
+    assertThat(saved.get(0).offer().description()).isEqualTo("desc a");
+    assertThat(saved.get(0).offer().domain()).isEqualTo("a.com");
+  }
+
+  @Test
+  void skipsOffersThatAlreadyHaveDetails() {
+    when(repository.readRawOffers()).thenReturn(List.of(withDetails("a"), pending("b")));
+    when(connector.fetchOfferPageHtml(url("b"))).thenReturn("<b>");
+    when(parser.parse("<b>")).thenReturn(new OfferDetails("desc b", "b.com"));
+
+    var result = service.fetchMissing(null);
+
+    assertThat(result.fetched()).isEqualTo(1);
+    assertThat(result.remaining()).isEqualTo(0);
+    verify(connector, never()).fetchOfferPageHtml(url("a"));
+  }
+
+  @Test
+  void limitCapsHowManyDetailsAreFetched() {
+    when(repository.readRawOffers()).thenReturn(List.of(pending("a"), pending("b"), pending("c")));
+    when(connector.fetchOfferPageHtml(url("a"))).thenReturn("<a>");
+    when(parser.parse("<a>")).thenReturn(new OfferDetails("desc a", "a.com"));
+
+    var result = service.fetchMissing(1);
+
+    assertThat(result.fetched()).isEqualTo(1);
+    assertThat(result.remaining()).isEqualTo(2);
+    verify(connector, never()).fetchOfferPageHtml(url("b"));
+    verify(connector, never()).fetchOfferPageHtml(url("c"));
+  }
+
+  @Test
+  void failedFetchLeavesOfferForALaterRun() {
+    when(repository.readRawOffers()).thenReturn(List.of(pending("a")));
+    when(connector.fetchOfferPageHtml(url("a"))).thenThrow(new IllegalStateException("boom"));
+
+    var result = service.fetchMissing(null);
+
+    assertThat(result.fetched()).isEqualTo(0);
+    assertThat(result.remaining()).isEqualTo(1);
+    assertThat(capturePersisted().get(0).hasDetails()).isFalse();
+  }
+}

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -19,12 +19,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import radar.model.DetailsResult;
 import radar.model.JobReport;
 import radar.model.RawJobOffer;
 import radar.model.SalaryRange;
 import radar.model.ScanResult;
 import radar.model.UserProfile;
 import radar.repository.JsonRepository;
+import radar.service.OfferDetailsService;
 import radar.service.ReporterService;
 import radar.service.ScraperService;
 
@@ -36,6 +38,7 @@ class WebControllersTest {
 
   private JsonRepository repository;
   private ScraperService scraperService;
+  private OfferDetailsService offerDetailsService;
   private ReporterService reporterService;
   private MockMvc mvc;
 
@@ -46,9 +49,10 @@ class WebControllersTest {
   void setUp() {
     repository = mock(JsonRepository.class);
     scraperService = mock(ScraperService.class);
+    offerDetailsService = mock(OfferDetailsService.class);
     reporterService = mock(ReporterService.class);
     mvc = MockMvcBuilders.standaloneSetup(
-        new ScanController(scraperService),
+        new ScanController(scraperService, offerDetailsService),
         new JobController(repository),
         new AnalyticsController(reporterService),
         new ProfileController(repository),
@@ -63,25 +67,32 @@ class WebControllersTest {
   }
 
   @Test
-  void postScanRunsSynchronouslyWithIncrementalDefaults() throws Exception {
+  void postScanScrapesThenFetchesDetailsWithIncrementalDefaults() throws Exception {
     when(scraperService.scan(false, null)).thenReturn(new ScanResult(5, 10));
+    when(offerDetailsService.fetchMissing(null)).thenReturn(new DetailsResult(3, 7));
 
     mvc.perform(post("/api/scan"))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.added").value(5))
-        .andExpect(jsonPath("$.total").value(10));
+        .andExpect(jsonPath("$.total").value(10))
+        .andExpect(jsonPath("$.detailsFetched").value(3))
+        .andExpect(jsonPath("$.detailsRemaining").value(7));
     verify(scraperService).scan(false, null);
+    verify(offerDetailsService).fetchMissing(null);
   }
 
   @Test
-  void postScanPassesFullFetchAndLimitParams() throws Exception {
+  void postScanPassesFullFetchAndLimitToBothStages() throws Exception {
     when(scraperService.scan(true, 20)).thenReturn(new ScanResult(20, 964));
+    when(offerDetailsService.fetchMissing(20)).thenReturn(new DetailsResult(20, 100));
 
     mvc.perform(post("/api/scan").param("fullFetch", "true").param("limit", "20"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.added").value(20));
+        .andExpect(jsonPath("$.added").value(20))
+        .andExpect(jsonPath("$.detailsFetched").value(20));
     verify(scraperService).scan(true, 20);
+    verify(offerDetailsService).fetchMissing(20);
   }
 
   @Test


### PR DESCRIPTION
## What

`POST /api/scan` now runs two stages in one call: **scrape** the listing into the raw-offers pool, then **fetch page details** (full `description` + company `domain`) for offers that don't have them yet. Still no Claude.

## Changes
- `JustJoinConnector.fetchOfferPageHtml(url)` — fetches an offer page's HTML.
- `OfferDetailsService.fetchMissing(limit)` — for offers with `detailsFetchedAt == null`: fetch page → `OfferDetailsParser` → `withDetails(...)`, write the pool back. Incremental, `limit`-bounded, a per-offer fetch failure is logged and left for a later run (doesn't fail the batch).
- `ScanController` — `/api/scan` returns `{added, total, detailsFetched, detailsRemaining}`; `limit` bounds both stages.
- `DetailsResult` / `ScanResponse` models.

## Note
Synchronous — use `limit` for large runs (a full pool fetch is minutes and would hit HTTP timeouts; async+SSE is a later step).

## Verified live
`DELETE /api/data` then `POST /api/scan?limit=5` → `{"added":5,"total":5,"detailsFetched":5,"detailsRemaining":0}`; all 5 got `description` (958–5109 chars), `domain` where present, and `detailsFetchedAt`. `./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)