### PR TITLE
refactor(model): VR-37 drop listing skills from RawJobOffer

### DIFF
--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -1,9 +1,10 @@
 # Key Models
 
 ## RawJobOffer
-`id, title, companyName, companySize, location, remote, publishedAt, experienceLevel, description, skills, salaryMin, salaryMax, currency, contractType, applyUrl, sourceConnector, domain`
+`id, title, companyName, companySize, location, remote, publishedAt, experienceLevel, description, salaryMin, salaryMax, currency, contractType, applyUrl, sourceConnector, domain`
 
 - `description` and `domain` come from the offer's own page (details step), not the listing API — `null` until fetched. `RawJobOffer.withDetails(description, domain)` returns an enriched copy.
+- No `skills` field: the listing's skill list is unreliable, so skills are extracted by Claude from the description at enrichment (→ `JobReport.keySkills`).
 
 ## StoredRawOffer (element of `raw-offers.json`)
 `offer (RawJobOffer), firstSeenAt, detailsFetchedAt`

--- a/src/main/java/radar/connector/JustJoinConnector.java
+++ b/src/main/java/radar/connector/JustJoinConnector.java
@@ -173,7 +173,6 @@ public class JustJoinConnector {
         textOrNull(n, "publishedAt"),
         textOrNull(n, "experienceLevel"),
         null, // description — see DESCRIPTION_NOTE
-        readSkills(n.path("requiredSkills")),
         intOrNull(salary, "from"),
         intOrNull(salary, "to"),
         upperOrNull(salary, "currency"),
@@ -181,21 +180,6 @@ public class JustJoinConnector {
         slug == null ? null : "https://justjoin.it/job-offer/" + slug,
         SOURCE,
         null); // domain — filled by the details step, not the list API
-  }
-
-  private static List<String> readSkills(JsonNode skillsNode) {
-    var skills = new ArrayList<String>();
-    if (skillsNode.isArray()) {
-      for (var s : skillsNode) {
-        // requiredSkills may be an array of strings or of objects with a "name" field
-        if (s.isTextual()) {
-          skills.add(s.asText());
-        } else if (s.hasNonNull("name")) {
-          skills.add(s.get("name").asText());
-        }
-      }
-    }
-    return skills;
   }
 
   private static String textOrNull(JsonNode node, String field) {

--- a/src/main/java/radar/model/RawJobOffer.java
+++ b/src/main/java/radar/model/RawJobOffer.java
@@ -1,13 +1,14 @@
 package radar.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.List;
 
 /**
  * A raw job offer as scraped from a source connector (e.g. JustJoin), before enrichment.
  *
  * <p>{@code description} and {@code domain} come from the offer's own page (the details step),
  * not the listing API — they are {@code null} on a freshly-scraped offer and filled in later.
+ * Skills are intentionally not carried here: the listing's skill list is unreliable, so skills are
+ * extracted by Claude from the description during enrichment (see {@code JobReport.keySkills}).
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record RawJobOffer(
@@ -20,7 +21,6 @@ public record RawJobOffer(
     String publishedAt,
     String experienceLevel,
     String description,
-    List<String> skills,
     Integer salaryMin,
     Integer salaryMax,
     String currency,
@@ -36,7 +36,7 @@ public record RawJobOffer(
    */
   public RawJobOffer withDetails(String description, String domain) {
     return new RawJobOffer(id, title, companyName, companySize, location, remote, publishedAt,
-        experienceLevel, description, skills, salaryMin, salaryMax, currency, contractType,
+        experienceLevel, description, salaryMin, salaryMax, currency, contractType,
         applyUrl, sourceConnector, domain);
   }
 }

--- a/src/main/java/radar/service/EnricherService.java
+++ b/src/main/java/radar/service/EnricherService.java
@@ -92,9 +92,6 @@ public class EnricherService {
     append(sb, "Remote", offer.remote() == null ? null : offer.remote().toString());
     append(sb, "Experience level", offer.experienceLevel());
     append(sb, "Contract type", offer.contractType());
-    if (offer.skills() != null && !offer.skills().isEmpty()) {
-      append(sb, "Listed skills", String.join(", ", offer.skills()));
-    }
     if (offer.salaryMin() != null || offer.salaryMax() != null) {
       append(sb, "Salary", offer.salaryMin() + " - " + offer.salaryMax() + " " + offer.currency());
     }

--- a/src/test/java/radar/connector/JustJoinConnectorTest.java
+++ b/src/test/java/radar/connector/JustJoinConnectorTest.java
@@ -54,7 +54,6 @@ class JustJoinConnectorTest {
     assertThat(o.remote()).isTrue();
     assertThat(o.experienceLevel()).isEqualTo("senior");
     assertThat(o.publishedAt()).isEqualTo("2026-06-10T16:39:31.585Z");
-    assertThat(o.skills()).containsExactly("Java", "Spring Boot", "AWS");
     assertThat(o.salaryMin()).isEqualTo(18000);
     assertThat(o.salaryMax()).isEqualTo(26000);
     assertThat(o.currency()).isEqualTo("PLN");
@@ -88,29 +87,10 @@ class JustJoinConnectorTest {
 
     var o = connector.parseOffers(page).get(0);
     assertThat(o.remote()).isFalse();
-    assertThat(o.skills()).isEmpty();
     assertThat(o.salaryMin()).isNull();
     assertThat(o.salaryMax()).isNull();
     assertThat(o.currency()).isNull();
     assertThat(o.contractType()).isNull();
-  }
-
-  @Test
-  void readsSkillsGivenAsObjects() throws Exception {
-    var page = json("""
-        {
-          "data": [
-            {
-              "guid": "g", "slug": "s", "title": "t", "companyName": "c",
-              "requiredSkills": [{"name": "Java", "level": 4}, {"name": "Kafka", "level": 2}],
-              "employmentTypes": []
-            }
-          ]
-        }
-        """);
-
-    var o = connector.parseOffers(page).get(0);
-    assertThat(o.skills()).containsExactly("Java", "Kafka");
   }
 
   @Test

--- a/src/test/java/radar/model/ModelSerializationTest.java
+++ b/src/test/java/radar/model/ModelSerializationTest.java
@@ -29,7 +29,7 @@ class ModelSerializationTest {
   void rawJobOfferRoundTrips() throws Exception {
     var offer = new RawJobOffer(
         "jj-123", "Senior Java Dev", "Acme", "50-100", "Warsaw", true,
-        "2026-07-04", "senior", "Build things", List.of("Java", "Spring"),
+        "2026-07-04", "senior", "Build things",
         18000, 26000, "PLN", "B2B", "https://justjoin.it/job/jj-123", "justjoin", null);
     assertRoundTrip(offer, RawJobOffer.class);
   }
@@ -46,7 +46,7 @@ class ModelSerializationTest {
   void jobReportRoundTrips() throws Exception {
     var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", false, "2026-07-04", "mid",
-        "desc", List.of("Java"), 12000, 18000, "PLN", "B2B", "url", "justjoin", null);
+        "desc", 12000, 18000, "PLN", "B2B", "url", "justjoin", null);
     var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
         List.of("on-call"), List.of("remote"), "system design", 8,
@@ -86,7 +86,7 @@ class ModelSerializationTest {
         null, List.of("Java"), List.of(), "product", "mid", List.of(), List.of(),
         "focus", 7, new SalaryRange(10000, 20000, "PLN"));
     var offer = new RawJobOffer(
-        "jj-2", "t", "c", null, null, null, null, null, null, null, null, null,
+        "jj-2", "t", "c", null, null, null, null, null, null, null, null,
         null, null, null, null, null);
     var attached = report.withRawJobOffer(offer);
     assertThat(attached.rawJobOffer()).isSameAs(offer);

--- a/src/test/java/radar/repository/JsonRepositoryTest.java
+++ b/src/test/java/radar/repository/JsonRepositoryTest.java
@@ -53,7 +53,7 @@ class JsonRepositoryTest {
   void jobsRoundTrip() {
     var offer = new RawJobOffer(
         "jj-1", "Java Dev", "Acme", "50", "Kraków", true, "2026-07-04", "mid",
-        null, List.of("Java"), 12000, 18000, "PLN", "b2b",
+        null, 12000, 18000, "PLN", "b2b",
         "https://justjoin.it/job-offer/jj-1", "justjoin", null);
     var report = new JobReport(
         offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
@@ -73,7 +73,7 @@ class JsonRepositoryTest {
   void deleteAllJobsRemovesEverySnapshotsJobsFile() {
     var report = new JobReport(
         new RawJobOffer("jj-1", "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
-            null, List.of("Java"), 12000, 18000, "PLN", "b2b", "url", "justjoin", null),
+            null, 12000, 18000, "PLN", "b2b", "url", "justjoin", null),
         List.of("Java"), List.of(), "product", "mid", List.of(), List.of(), "focus", 8,
         new SalaryRange(12000, 18000, "PLN"));
     repo.saveJobs("2026-07-04", List.of(report));

--- a/src/test/java/radar/service/EnricherServiceTest.java
+++ b/src/test/java/radar/service/EnricherServiceTest.java
@@ -23,7 +23,7 @@ class EnricherServiceTest {
 
   private RawJobOffer offer(String id, String title) {
     return new RawJobOffer(id, title, "Acme", null, "Kraków", true, "2026-07-04", "senior",
-        null, List.of("Java", "AWS"), 18000, 26000, "PLN", "b2b",
+        null, 18000, 26000, "PLN", "b2b",
         "https://justjoin.it/job-offer/" + id, "justjoin", null);
   }
 

--- a/src/test/java/radar/service/OfferDetailsServiceTest.java
+++ b/src/test/java/radar/service/OfferDetailsServiceTest.java
@@ -45,7 +45,7 @@ class OfferDetailsServiceTest {
 
   private RawJobOffer offer(String id) {
     return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
-        null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
+        null, null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
         "justjoin", null);
   }
 

--- a/src/test/java/radar/service/ReporterServiceTest.java
+++ b/src/test/java/radar/service/ReporterServiceTest.java
@@ -28,7 +28,7 @@ class ReporterServiceTest {
   private JobReport report(String company, boolean remote, String projectType, Integer salaryMin,
       List<String> keySkills) {
     var offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
-        "Kraków", remote, "2026-07-04", "senior", null, keySkills, salaryMin,
+        "Kraków", remote, "2026-07-04", "senior", null, salaryMin,
         salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin", null);
     return new JobReport(offer, keySkills, List.of(), projectType, "senior", List.of(), List.of(),
         "focus", 7, new SalaryRange(salaryMin, salaryMin == null ? null : salaryMin + 5000, "PLN"));

--- a/src/test/java/radar/service/ScraperServiceTest.java
+++ b/src/test/java/radar/service/ScraperServiceTest.java
@@ -42,7 +42,7 @@ class ScraperServiceTest {
 
   private RawJobOffer offer(String id) {
     return new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
-        null, List.of("Java"), null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
+        null, null, null, null, "b2b", "https://justjoin.it/job-offer/" + id,
         "justjoin", null);
   }
 

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -61,7 +61,7 @@ class WebControllersTest {
 
   private JobReport report(String id, int score) {
     var offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
-        "senior", null, List.of("Java"), 18000, 26000, "PLN", "b2b", "url", "justjoin", null);
+        "senior", null, 18000, 26000, "PLN", "b2b", "url", "justjoin", null);
     return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
         List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));
   }


### PR DESCRIPTION
## What

Removes the `skills` field from `RawJobOffer`. The listing API's `requiredSkills` is unreliable (often `null`), and skills will instead be extracted by Claude from the full `description` at enrichment (→ `JobReport.keySkills`).

## Changes
- `RawJobOffer`: remove the `skills` component (and its `withDetails` arg).
- `JustJoinConnector`: drop `readSkills` parsing of `requiredSkills`.
- `EnricherService`: drop the "Listed skills" line from the prompt.
- Update all constructor call sites; remove the skills-parsing tests.
- `models.md` documents the removal.

`./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)