### PR TITLE
refactor(model): VR-38 reshape JobReport enrichment schema

### DIFF
--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -18,7 +18,9 @@
 `currentSkills, experienceYears, preferredType, preferredRemote, salaryMin, currency, contractType, locations, minMatchScore`
 
 ## JobReport
-`rawJobOffer, keySkills, niceToHave, projectType, realSeniority, redFlags, greenFlags, interviewFocus, matchScore (1-10), salary`
+`rawJobOffer, skills, responsibilities, projectDescription, requirements, realSeniority, matchScore (1-10)`
+
+- `skills`: all technical skills Claude found in the offer text. `responsibilities`/`projectDescription`: Claude's own-words summary. `requirements`: list. Salary/domain live on `rawJobOffer`, not duplicated here.
 
 ## Analytics
-`date, totalScanned, skillFrequency, topCompanies, salaryDistribution, projectTypeBreakdown, remotePercentage`
+`date, totalScanned, skillFrequency, topCompanies, salaryDistribution, remotePercentage`

--- a/src/main/java/radar/model/Analytics.java
+++ b/src/main/java/radar/model/Analytics.java
@@ -15,7 +15,6 @@ public record Analytics(
     Map<String, Integer> skillFrequency,
     List<String> topCompanies,
     SalaryRange salaryDistribution,
-    Map<String, Double> projectTypeBreakdown,
     double remotePercentage
 ) {
 }

--- a/src/main/java/radar/model/JobReport.java
+++ b/src/main/java/radar/model/JobReport.java
@@ -10,15 +10,12 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record JobReport(
     RawJobOffer rawJobOffer,
-    List<String> keySkills,
-    List<String> niceToHave,
-    String projectType,
+    List<String> skills,
+    String responsibilities,
+    String projectDescription,
+    List<String> requirements,
     String realSeniority,
-    List<String> redFlags,
-    List<String> greenFlags,
-    String interviewFocus,
-    int matchScore,
-    SalaryRange salary
+    int matchScore
 ) {
 
   /**
@@ -26,7 +23,7 @@ public record JobReport(
    * fields without the original offer, so the enricher stitches it back on afterwards.
    */
   public JobReport withRawJobOffer(RawJobOffer offer) {
-    return new JobReport(offer, keySkills, niceToHave, projectType, realSeniority,
-        redFlags, greenFlags, interviewFocus, matchScore, salary);
+    return new JobReport(offer, skills, responsibilities, projectDescription, requirements,
+        realSeniority, matchScore);
   }
 }

--- a/src/main/java/radar/service/EnricherService.java
+++ b/src/main/java/radar/service/EnricherService.java
@@ -104,8 +104,8 @@ public class EnricherService {
   /** Maps the model's result onto a JobReport, clamping the score to the valid 1-10 range. */
   JobReport toReport(EnrichmentResult r, RawJobOffer offer) {
     var score = Math.max(MIN_SCORE, Math.min(MAX_SCORE, r.matchScore()));
-    return new JobReport(offer, r.keySkills(), r.niceToHave(), r.projectType(), r.realSeniority(),
-        r.redFlags(), r.greenFlags(), r.interviewFocus(), score, r.salary());
+    return new JobReport(offer, r.skills(), r.responsibilities(), r.projectDescription(),
+        r.requirements(), r.realSeniority(), score);
   }
 
   private static void append(StringBuilder sb, String label, String value) {

--- a/src/main/java/radar/service/EnrichmentResult.java
+++ b/src/main/java/radar/service/EnrichmentResult.java
@@ -3,32 +3,30 @@ package radar.service;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
-import radar.model.SalaryRange;
 
 /**
- * The structured JSON Claude Haiku returns for a single offer — every {@link radar.model.JobReport}
- * field except the raw offer, which the enricher attaches afterwards. Field descriptions are sent to
- * the model as part of the derived JSON schema, so keep them instructive.
+ * The structured JSON Claude returns for a single offer — every {@link radar.model.JobReport} field
+ * except the raw offer, which the enricher attaches afterwards. Field descriptions are sent to the
+ * model as part of the derived JSON schema, so keep them instructive.
  */
 @JsonClassDescription("Analysis of a single job offer relative to the user's profile.")
 public record EnrichmentResult(
-    @JsonPropertyDescription("The core technologies the role genuinely requires day-to-day.")
-    List<String> keySkills,
-    @JsonPropertyDescription("Skills that are a bonus but not required.")
-    List<String> niceToHave,
-    @JsonPropertyDescription("Type of work, e.g. product, outsourcing, consulting, startup.")
-    String projectType,
+    @JsonPropertyDescription(
+        "Every technical skill or technology mentioned anywhere in the offer text "
+            + "(languages, frameworks, tools, databases, cloud, methodologies).")
+    List<String> skills,
+    @JsonPropertyDescription(
+        "The day-to-day responsibilities, summarised in your own words, a few short sentences.")
+    String responsibilities,
+    @JsonPropertyDescription(
+        "What the project/product is about, summarised in your own words, a few short sentences.")
+    String projectDescription,
+    @JsonPropertyDescription("The concrete requirements the candidate must meet, as a list.")
+    List<String> requirements,
     @JsonPropertyDescription("The real seniority the role demands: junior, mid, senior, or lead.")
     String realSeniority,
-    @JsonPropertyDescription("Concerning signals: vague scope, unrealistic stack, low pay, churn.")
-    List<String> redFlags,
-    @JsonPropertyDescription("Positive signals: clear tech, good pay, remote, strong team.")
-    List<String> greenFlags,
-    @JsonPropertyDescription("What the candidate should prepare for interviews at this role.")
-    String interviewFocus,
-    @JsonPropertyDescription("How well the offer matches the user's profile, from 1 (poor) to 10 (excellent).")
-    int matchScore,
-    @JsonPropertyDescription("The offer's salary range as understood from the posting.")
-    SalaryRange salary
+    @JsonPropertyDescription(
+        "How well the offer matches the user's profile, from 1 (poor) to 10 (excellent).")
+    int matchScore
 ) {
 }

--- a/src/main/java/radar/service/ReporterService.java
+++ b/src/main/java/radar/service/ReporterService.java
@@ -5,10 +5,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import radar.model.Analytics;
 import radar.model.JobReport;
+import radar.model.RawJobOffer;
 import radar.model.SalaryRange;
 import radar.repository.JsonRepository;
 
@@ -36,7 +36,6 @@ public class ReporterService {
         skillFrequency(allReports),
         topCompanies(allReports),
         salaryDistribution(allReports),
-        projectTypeBreakdown(allReports, total),
         remotePercentage(allReports, total));
   }
 
@@ -63,8 +62,8 @@ public class ReporterService {
   private Map<String, Integer> skillFrequency(List<JobReport> reports) {
     var counts = new HashMap<String, Integer>();
     for (var report : reports) {
-      if (report.keySkills() != null) {
-        for (var skill : report.keySkills()) {
+      if (report.skills() != null) {
+        for (var skill : report.skills()) {
           counts.merge(skill, 1, Integer::sum);
         }
       }
@@ -89,36 +88,21 @@ public class ReporterService {
 
   private SalaryRange salaryDistribution(List<JobReport> reports) {
     var mins = reports.stream()
-        .map(JobReport::salary)
-        .filter(s -> s != null && s.min() != null)
-        .map(SalaryRange::min)
+        .map(JobReport::rawJobOffer)
+        .filter(o -> o != null && o.salaryMin() != null)
+        .map(RawJobOffer::salaryMin)
         .sorted()
         .toList();
     if (mins.isEmpty()) {
       return new SalaryRange(null, null, null);
     }
     var currency = reports.stream()
-        .map(JobReport::salary)
-        .filter(s -> s != null && s.currency() != null)
-        .map(SalaryRange::currency)
+        .map(JobReport::rawJobOffer)
+        .filter(o -> o != null && o.currency() != null)
+        .map(RawJobOffer::currency)
         .findFirst()
         .orElse(null);
     return new SalaryRange(mins.get(0), mins.get(mins.size() - 1), currency);
-  }
-
-  private Map<String, Double> projectTypeBreakdown(List<JobReport> reports, int total) {
-    if (total == 0) {
-      return new LinkedHashMap<>();
-    }
-    var counts = reports.stream()
-        .map(JobReport::projectType)
-        .filter(t -> t != null && !t.isBlank())
-        .collect(Collectors.groupingBy(t -> t, Collectors.counting()));
-    var breakdown = new LinkedHashMap<String, Double>();
-    counts.entrySet().stream()
-        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-        .forEach(e -> breakdown.put(e.getKey(), e.getValue() * 100.0 / total));
-    return breakdown;
   }
 
   private double remotePercentage(List<JobReport> reports, int total) {

--- a/src/test/java/radar/model/ModelSerializationTest.java
+++ b/src/test/java/radar/model/ModelSerializationTest.java
@@ -48,9 +48,8 @@ class ModelSerializationTest {
         "jj-1", "Java Dev", "Acme", "50", "Kraków", false, "2026-07-04", "mid",
         "desc", 12000, 18000, "PLN", "B2B", "url", "justjoin", null);
     var report = new JobReport(
-        offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
-        List.of("on-call"), List.of("remote"), "system design", 8,
-        new SalaryRange(12000, 18000, "PLN"));
+        offer, List.of("Java", "SQL"), "Build services.", "A payments platform.",
+        List.of("5+ years Java"), "mid", 8);
     assertRoundTrip(report, JobReport.class);
   }
 
@@ -58,8 +57,7 @@ class ModelSerializationTest {
   void analyticsRoundTrips() throws Exception {
     var analytics = new Analytics(
         "2026-07-04", 42, Map.of("Java", 30, "Spring", 20), List.of("Acme", "Globex"),
-        new SalaryRange(10000, 30000, "PLN"), Map.of("product", 0.6, "outsourcing", 0.4),
-        66.7);
+        new SalaryRange(10000, 30000, "PLN"), 66.7);
     assertRoundTrip(analytics, Analytics.class);
   }
 
@@ -83,8 +81,7 @@ class ModelSerializationTest {
   @Test
   void withRawJobOfferAttachesOffer() {
     var report = new JobReport(
-        null, List.of("Java"), List.of(), "product", "mid", List.of(), List.of(),
-        "focus", 7, new SalaryRange(10000, 20000, "PLN"));
+        null, List.of("Java"), "resp", "proj", List.of(), "mid", 7);
     var offer = new RawJobOffer(
         "jj-2", "t", "c", null, null, null, null, null, null, null, null,
         null, null, null, null, null);

--- a/src/test/java/radar/repository/JsonRepositoryTest.java
+++ b/src/test/java/radar/repository/JsonRepositoryTest.java
@@ -56,9 +56,8 @@ class JsonRepositoryTest {
         null, 12000, 18000, "PLN", "b2b",
         "https://justjoin.it/job-offer/jj-1", "justjoin", null);
     var report = new JobReport(
-        offer, List.of("Java", "SQL"), List.of("Kafka"), "product", "mid",
-        List.of("on-call"), List.of("remote"), "system design", 8,
-        new SalaryRange(12000, 18000, "PLN"));
+        offer, List.of("Java", "SQL"), "Build services.", "A platform.",
+        List.of("5+ years Java"), "mid", 8);
 
     repo.saveJobs("2026-07-04", List.of(report));
     assertThat(repo.loadJobs("2026-07-04")).containsExactly(report);
@@ -74,13 +73,12 @@ class JsonRepositoryTest {
     var report = new JobReport(
         new RawJobOffer("jj-1", "Java Dev", "Acme", null, "Kraków", true, "2026-07-04", "mid",
             null, 12000, 18000, "PLN", "b2b", "url", "justjoin", null),
-        List.of("Java"), List.of(), "product", "mid", List.of(), List.of(), "focus", 8,
-        new SalaryRange(12000, 18000, "PLN"));
+        List.of("Java"), "resp", "proj", List.of(), "mid", 8);
     repo.saveJobs("2026-07-04", List.of(report));
     repo.saveJobs("2026-07-05", List.of(report));
     // a snapshot with only analytics (no jobs.json) must not be counted
     repo.saveAnalytics("2026-07-06",
-        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, 0.0));
 
     var deleted = repo.deleteAllJobs();
 
@@ -95,7 +93,7 @@ class JsonRepositoryTest {
     repo.saveRawOffers(List.of());
     repo.saveJobs("2026-07-04", List.of());
     repo.saveAnalytics("2026-07-05",
-        new Analytics("2026-07-05", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+        new Analytics("2026-07-05", 0, Map.of(), List.of(), null, 0.0));
     var gitkeep = tmp.resolve("data").resolve(".gitkeep");
     Files.createFile(gitkeep);
 
@@ -113,7 +111,7 @@ class JsonRepositoryTest {
   void analyticsRoundTrip() {
     var analytics = new Analytics(
         "2026-07-04", 42, Map.of("Java", 30, "Spring", 20), List.of("Acme"),
-        new SalaryRange(10000, 30000, "PLN"), Map.of("product", 0.6), 66.7);
+        new SalaryRange(10000, 30000, "PLN"), 66.7);
 
     repo.saveAnalytics("2026-07-04", analytics);
     assertThat(repo.loadAnalytics("2026-07-04")).isEqualTo(analytics);
@@ -122,16 +120,16 @@ class JsonRepositoryTest {
   @Test
   void saveCreatesDateDirectory() {
     repo.saveAnalytics("2026-07-04",
-        new Analytics("2026-07-04", 1, Map.of(), List.of(), null, Map.of(), 0.0));
+        new Analytics("2026-07-04", 1, Map.of(), List.of(), null, 0.0));
     assertThat(Files.isDirectory(tmp.resolve("data").resolve("2026-07-04"))).isTrue();
   }
 
   @Test
   void listDatesReturnsOnlyDateDirectoriesSorted() throws Exception {
     repo.saveAnalytics("2026-07-06",
-        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+        new Analytics("2026-07-06", 0, Map.of(), List.of(), null, 0.0));
     repo.saveAnalytics("2026-07-04",
-        new Analytics("2026-07-04", 0, Map.of(), List.of(), null, Map.of(), 0.0));
+        new Analytics("2026-07-04", 0, Map.of(), List.of(), null, 0.0));
     // noise that must be ignored
     Files.createDirectories(tmp.resolve("data").resolve("not-a-date"));
     repo.writeProfile(new UserProfile(List.of(), 0, null, false, 0, "PLN", null, List.of(), 0));

--- a/src/test/java/radar/service/EnricherServiceTest.java
+++ b/src/test/java/radar/service/EnricherServiceTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import radar.model.RawJobOffer;
 import radar.model.ScanProgress;
-import radar.model.SalaryRange;
 import radar.model.UserProfile;
 
 class EnricherServiceTest {
@@ -48,15 +47,12 @@ class EnricherServiceTest {
   void validJsonProducesJobReportWithOfferAttached() {
     var json = """
         {
-          "keySkills": ["Java", "Spring Boot"],
-          "niceToHave": ["Kafka"],
-          "projectType": "product",
+          "skills": ["Java", "Spring Boot", "Kafka"],
+          "responsibilities": "Build backend services.",
+          "projectDescription": "A payments platform.",
+          "requirements": ["5+ years Java", "Spring"],
           "realSeniority": "senior",
-          "redFlags": ["on-call"],
-          "greenFlags": ["remote", "clear stack"],
-          "interviewFocus": "system design",
-          "matchScore": 8,
-          "salary": {"min": 18000, "max": 26000, "currency": "PLN"}
+          "matchScore": 8
         }
         """;
     var o = offer("jj-1", "Senior Java Dev");
@@ -64,15 +60,12 @@ class EnricherServiceTest {
     var report = withCannedJson(json).enrich(o, profile);
 
     assertThat(report.rawJobOffer()).isSameAs(o);
-    assertThat(report.keySkills()).containsExactly("Java", "Spring Boot");
-    assertThat(report.niceToHave()).containsExactly("Kafka");
-    assertThat(report.projectType()).isEqualTo("product");
+    assertThat(report.skills()).containsExactly("Java", "Spring Boot", "Kafka");
+    assertThat(report.responsibilities()).isEqualTo("Build backend services.");
+    assertThat(report.projectDescription()).isEqualTo("A payments platform.");
+    assertThat(report.requirements()).containsExactly("5+ years Java", "Spring");
     assertThat(report.realSeniority()).isEqualTo("senior");
-    assertThat(report.redFlags()).containsExactly("on-call");
-    assertThat(report.greenFlags()).containsExactly("remote", "clear stack");
-    assertThat(report.interviewFocus()).isEqualTo("system design");
     assertThat(report.matchScore()).isEqualTo(8);
-    assertThat(report.salary()).isEqualTo(new SalaryRange(18000, 26000, "PLN"));
   }
 
   @Test
@@ -91,9 +84,8 @@ class EnricherServiceTest {
   @Test
   void enrichAllEmitsOneEnrichingProgressPerOffer() {
     var json = """
-        {"keySkills":[],"niceToHave":[],"projectType":"product","realSeniority":"mid",
-         "redFlags":[],"greenFlags":[],"interviewFocus":"basics","matchScore":5,
-         "salary":{"min":10000,"max":15000,"currency":"PLN"}}
+        {"skills":[],"responsibilities":"r","projectDescription":"p","requirements":[],
+         "realSeniority":"mid","matchScore":5}
         """;
     var svc = withCannedJson(json);
     var offers = List.of(offer("a", "A"), offer("b", "B"), offer("c", "C"));
@@ -122,7 +114,6 @@ class EnricherServiceTest {
   }
 
   private EnrichmentResult result(int score) {
-    return new EnrichmentResult(List.of("Java"), List.of(), "product", "mid", List.of(), List.of(),
-        "focus", score, new SalaryRange(10000, 20000, "PLN"));
+    return new EnrichmentResult(List.of("Java"), "resp", "proj", List.of(), "mid", score);
   }
 }

--- a/src/test/java/radar/service/ReporterServiceTest.java
+++ b/src/test/java/radar/service/ReporterServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import radar.model.Analytics;
 import radar.model.JobReport;
 import radar.model.RawJobOffer;
-import radar.model.SalaryRange;
 import radar.repository.JsonRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,8 +29,7 @@ class ReporterServiceTest {
     var offer = new RawJobOffer("id-" + company + salaryMin, "Java Dev", company, null,
         "Kraków", remote, "2026-07-04", "senior", null, salaryMin,
         salaryMin == null ? null : salaryMin + 5000, "PLN", "b2b", "url", "justjoin", null);
-    return new JobReport(offer, keySkills, List.of(), projectType, "senior", List.of(), List.of(),
-        "focus", 7, new SalaryRange(salaryMin, salaryMin == null ? null : salaryMin + 5000, "PLN"));
+    return new JobReport(offer, keySkills, "resp", "proj", List.of(), "senior", 7);
   }
 
   @Test
@@ -99,22 +97,6 @@ class ReporterServiceTest {
   }
 
   @Test
-  void projectTypeBreakdownSumsToAround100Percent() {
-    var reports = List.of(
-        report("A", true, "product", 10000, List.of("Java")),
-        report("B", true, "product", 12000, List.of("Java")),
-        report("C", false, "outsourcing", 11000, List.of("Java")),
-        report("D", true, "product", 13000, List.of("Java")));
-
-    var breakdown = reporter.buildAnalytics("2026-07-04", reports)
-        .projectTypeBreakdown();
-
-    assertThat(breakdown.get("product")).isEqualTo(75.0);
-    assertThat(breakdown.get("outsourcing")).isEqualTo(25.0);
-    assertThat(breakdown.values().stream().mapToDouble(Double::doubleValue).sum()).isEqualTo(100.0);
-  }
-
-  @Test
   void computeTrendsMergesSkillFrequencyAcrossSnapshots() {
     when(repository.listDates()).thenReturn(List.of("2026-07-04", "2026-07-05"));
     when(repository.loadAnalytics("2026-07-04")).thenReturn(analytics(Map.of("Java", 3, "Spring", 2)));
@@ -140,6 +122,6 @@ class ReporterServiceTest {
   }
 
   private Analytics analytics(Map<String, Integer> skills) {
-    return new Analytics("2026-07-04", 0, skills, List.of(), null, Map.of(), 0.0);
+    return new Analytics("2026-07-04", 0, skills, List.of(), null, 0.0);
   }
 }

--- a/src/test/java/radar/web/WebControllersTest.java
+++ b/src/test/java/radar/web/WebControllersTest.java
@@ -22,7 +22,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import radar.model.DetailsResult;
 import radar.model.JobReport;
 import radar.model.RawJobOffer;
-import radar.model.SalaryRange;
 import radar.model.ScanResult;
 import radar.model.UserProfile;
 import radar.repository.JsonRepository;
@@ -62,8 +61,7 @@ class WebControllersTest {
   private JobReport report(String id, int score) {
     var offer = new RawJobOffer(id, "Java Dev", "Acme", null, "Kraków", true, "2026-07-04",
         "senior", null, 18000, 26000, "PLN", "b2b", "url", "justjoin", null);
-    return new JobReport(offer, List.of("Java"), List.of(), "product", "senior", List.of(),
-        List.of(), "focus", score, new SalaryRange(18000, 26000, "PLN"));
+    return new JobReport(offer, List.of("Java"), "resp", "proj", List.of(), "senior", score);
   }
 
   @Test


### PR DESCRIPTION
Aligns the Claude output with the agreed report field set.

**JobReport / EnrichmentResult now:** `skills`, `responsibilities` (own words), `projectDescription` (own words), `requirements` (list), `realSeniority`, `matchScore`.

**Dropped:** `keySkills`→`skills` rename, `niceToHave`, `projectType`, `redFlags`, `greenFlags`, `interviewFocus`, and the report's `salary` (salary + `domain` already live on `rawJobOffer`).

- `EnricherService.toReport` maps the new fields.
- `Analytics` loses `projectTypeBreakdown`; `ReporterService` reads salary from `rawJobOffer` and skills from `skills`.
- All model tests updated; `models.md` documents the new shape.

`./gradlew test` green. No evaluate wiring yet — that's the next chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)